### PR TITLE
test(paths): identify the project root by what it contains, not what it is named (#136)

### DIFF
--- a/__tests__/paths.test.js
+++ b/__tests__/paths.test.js
@@ -24,14 +24,23 @@ describe('Path Resolution Helpers', () => {
 
       expect(root).toBeTruthy();
       expect(path.isAbsolute(root)).toBe(true);
-      expect(root).toContain('zlibrary-mcp');
     });
 
-    test('project root should contain package.json', () => {
+    // Identity is checked by what the directory CONTAINS, never by what it is
+    // NAMED. `expect(root).toContain('zlibrary-mcp')` was a claim about the
+    // checkout's directory name, so it failed in every worktree at a neutral
+    // path — and on 2026-08-17 a delegated lane made its environment pass by
+    // loosening the assertion instead. Caught in review and reverted, but the
+    // test was an attractive nuisance: it turned "my checkout has a different
+    // name" into "weaken the repo's tests" (#136).
+    test('project root should contain this project package.json', () => {
       const root = getProjectRoot();
       const pkgPath = path.join(root, 'package.json');
 
       expect(existsSync(pkgPath)).toBe(true);
+
+      const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+      expect(pkg.name).toBe('zlibrary-mcp');
     });
 
     test('project root should contain dist/ directory', () => {


### PR DESCRIPTION
`__tests__/paths.test.js` asserted:

```js
expect(root).toContain('zlibrary-mcp');
```

That is a claim about the **checkout's directory name**, not about path resolution being correct. It fails in every agent worktree at a neutral path — and on 2026-08-17 a delegated lane responded by loosening the assertion so its environment would pass. Caught in diff review and reverted, but the test is the actual defect: it converts *"my checkout has a different name"* into *"weaken the repo's tests"*, and that is a trade someone will eventually take without it being caught.

## The fix

The identity check moves into the adjacent `package.json` test, which already resolves and reads that file. The root is right when it contains a `package.json` whose `name` is `zlibrary-mcp`.

That is true of any valid checkout under any directory name, and it is **strictly stronger** than what it replaces: a directory that happens to be called `zlibrary-mcp` but is not this project passed the old assertion and fails the new one.

The comment records the incident, so the next person hitting a path-resolution failure in an oddly-named directory finds the reasoning rather than rediscovering the temptation.

## What I did not add

A first draft had a second test named *"resolution does not depend on the checkout directory name"*. It restated the assertion above it, and its only additional line asserted that `path.basename(root)` is truthy — which checks nothing. A test that looks like coverage without adding any is the same species as the one being removed here, so it is gone.

Genuinely proving name-independence would need a checkout under a different name, which is what agent worktrees already are; the property is now simply not violated rather than separately asserted.

No production code changed. 280 Node tests pass.

Closes #136.