### PR TITLE
feat(sources): report source and route to the caller (#101, #107)

### DIFF
--- a/.claude/ARCHITECTURE.md
+++ b/.claude/ARCHITECTURE.md
@@ -68,6 +68,25 @@ All registered via `server.tool()` (McpServer API, MCP SDK 1.25+). The README to
 table is CI-enforced against `src/index.ts` by `scripts/validate-readme-tools.sh` —
 if the sets diverge, the build fails.
 
+### Source and route reporting (#96)
+
+Two reporting surfaces, split by what a fact costs to obtain, sharing one vocabulary in
+`lib/sources/capabilities.py`:
+
+| Surface | Carries | Cost |
+|---|---|---|
+| `routing` on every `search_multi_source` response | `requested`, `served_by`, `fell_back`, and a symmetric per-source entry (`available`, `routes`, `daily_limit`, `note`) | Local only — no network call may be added here |
+| `get_download_limits` | The same entries, plus `details`, with quotas filled in for the requested sources | Z-Library alone costs an EAPI profile call; `sources` narrows the request to avoid it |
+
+Acquisition returns nested `provenance` (`source`, `route`, `mirror`, `host`) — nested
+because `search_multi_source` spreads `**r.extra` into each book dict, so a flat `source`
+key would collide silently.
+
+Two rules the code enforces and a refactor can break quietly: every source carries the
+same key set (invariant 4 — report, never rank), and `daily_limit.state` keeps *no limit
+exists*, *not known here*, and *a concrete number* distinct rather than collapsing them
+onto `null`.
+
 ### Structured RAG Output Bundle (v1.2.1)
 
 `process_document_for_rag` and `download_book_to_file` (with `process_for_rag`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The source/route reporting contract** decided on #96, in three surfaces
+  (#101, #107). `search_multi_source` now returns a `routing` block naming what
+  was requested, what served it, whether a fallback happened, and each source's
+  current routes and daily limit — every field read from configuration, so it
+  costs no extra request. `download_book_to_file` returns nested `provenance`
+  with the source, route, mirror, and host that actually served the file;
+  before this those went to `logger.warning` on stderr and never reached the
+  caller. `get_download_limits` reports every source rather than Z-Library
+  alone, and takes an optional `sources` parameter so a Library Genesis
+  question makes no Z-Library profile call. A daily limit is three-valued — *no
+  limit exists*, *a limit exists and is not known here*, *a concrete number* —
+  and never collapses onto `null`. The tool count stays 13.
+
 - `npm run audit:release` ([scripts/release-audit.mjs](scripts/release-audit.mjs)) and a
   weekly `Release Record Audit` workflow, checking that the project's record of itself is
   still true. **Drift:** every tag has a GitHub Release and a CHANGELOG section, every
@@ -87,7 +100,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   source.
 - The scheduled upstream contract check no longer fails spuriously (#71).
 
+### Removed
+
+- **`sources_used` on `search_multi_source` responses.** It was derived from the
+  results, so an `annas`-requested search that fell back reported `["libgen"]`
+  with no trace of the substitution — the reporting half of the bug #74 fixed in
+  routing. Superseded by `routing.served_by` and `routing.fell_back` (#96).
+
 ### Changed
+
+- **`get_download_limits` reports per source.** Its old top-level `daily_limit`
+  / `daily_remaining` / `downloads_today` / `is_premium` keys are replaced by
+  `sources.zlibrary`, whose numbers live under `daily_limit` and whose
+  `is_premium` lives under `details`. A tool whose name never named a source
+  was answering as though it had (#107). A Z-Library outage now degrades that
+  one entry to `unknown` with the reason attached rather than failing the whole
+  call, so a credential-free Library Genesis setup still gets an answer.
 
 - `CONTEXT.md` added as the terminology glossary, splitting the overloaded term
   "keyless" into *keyed fast_download*, *operator-cookie slow_download*, and

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -40,10 +40,15 @@ _Avoid_: Method, channel, path
 **Provenance**:
 The record of which source, route, mirror, and host served a given result.
 
-Note that provenance is currently **written to the logs, not returned to the caller**.
-`DownloadResult` carries `url`, `source`, and quota only. Making it part of the returned
-result is an open design decision (#96), so treat this entry as naming the concept rather
-than describing a guarantee the server presently offers.
+Returned to the caller as a nested `provenance` object on every acquisition, alongside
+the file path — `{source, route, mirror, host}`, with `null` where a route has no
+analogue for a field. It describes the transfer and never the document. `DownloadResult`
+carries `route`, `mirror`, and `host` for the adapters to fill in; before #101 it carried
+`url`, `source`, and quota only, and provenance reached the logs and stopped there.
+
+The discovery-time counterpart is the `routing` block on every `search_multi_source`
+response: `requested`, `served_by`, `fell_back`, and a symmetric per-source entry naming
+each source's routes and daily limit. Both shapes were decided on #96.
 
 ### Anna's Archive routes
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ flowchart LR
 
 | Tool | Description |
 |------|-------------|
-| `get_download_limits` | Check daily download quota |
+| `get_download_limits` | Check each source's daily download quota |
 | `get_download_history` | View recent downloads |
 
 For complete parameter documentation, types, and examples, see [API Reference](docs/api.md).
@@ -151,6 +151,13 @@ capabilities.
 | Library Genesis | No | None | Yes | Yes |
 | Z-Library | Yes | Approximately 10 books | Yes | Yes |
 | Anna's Archive | API key for downloads | Set by membership | Yes | Only with an API key |
+
+The server reports these constraints rather than choosing between them. Every
+`search_multi_source` response carries a `routing` block naming which source you asked
+for, which one answered, whether a substitution happened, and what each source can
+currently do. Every download response carries a `provenance` block naming the source,
+route, mirror, and host that served the file. Neither ranks the sources: the calling
+agent decides. See [API Reference](docs/api.md) for the field shapes.
 
 ### Library Genesis
 
@@ -186,7 +193,9 @@ config. Without these variables, the Z-Library tools fail when you call them. Th
 tools continue to work.
 
 Z-Library applies a daily download limit of approximately 10 books. Call
-`get_download_limits` to check your remaining quota.
+`get_download_limits` to check your remaining quota. That tool reports every source, not
+only Z-Library; Z-Library is the one whose answer costs a round-trip, so pass
+`sources: ["libgen"]` when Z-Library is not the source you are asking about.
 
 ### Anna's Archive
 

--- a/__tests__/index-handlers-extended.test.js
+++ b/__tests__/index-handlers-extended.test.js
@@ -563,7 +563,7 @@ describe('Tool Handlers - Extended Coverage', () => {
       ['search_books', 'searchBooks', { query: 'x' }, 1],
       ['full_text_search', 'fullTextSearch', { query: 'x' }, 1],
       ['get_download_history', 'getDownloadHistory', {}, 1],
-      ['get_download_limits', 'getDownloadLimits', {}, 0],
+      ['get_download_limits', 'getDownloadLimits', {}, 1],
       ['download_book_to_file', 'downloadBookToFile', { bookDetails: { id: '1' } }, 1],
       ['process_document_for_rag', 'processDocumentForRag', { file_path: '/a.epub' }, 1],
       ['get_book_metadata', 'getBookMetadata', { bookId: '1', bookHash: 'h' }, 3],

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -114,6 +114,39 @@ describe('MCP Server', () => {
     expect(registeredToolNames).toContain('search_by_author');
     expect(registeredToolNames).toContain('fetch_booklist');
     expect(registeredToolNames).toContain('search_advanced');
+    expect(registeredToolNames).toContain('search_multi_source');
+    // #96 held the count at 13 by extending existing tools. The routing
+    // contract adds two reporting surfaces and no fourteenth tool.
+    expect(registeredToolNames).toHaveLength(13);
+  });
+
+  describe('get_download_limits accepts a per-source narrowing (#107)', () => {
+    test('accepts canonical source names', async () => {
+      const { toolRegistry } = await import('../dist/index.js');
+      const parsed = toolRegistry.get_download_limits.schema.parse({
+        sources: ['libgen', 'annas_archive'],
+      });
+      expect(parsed.sources).toEqual(['libgen', 'annas_archive']);
+    });
+
+    test('omitting sources means every source', async () => {
+      const { toolRegistry } = await import('../dist/index.js');
+      expect(toolRegistry.get_download_limits.schema.parse({}).sources).toBeUndefined();
+    });
+
+    test('rejects a source this server does not read from', async () => {
+      const { toolRegistry } = await import('../dist/index.js');
+      expect(() =>
+        toolRegistry.get_download_limits.schema.parse({ sources: ['gutenberg'] }),
+      ).toThrow();
+    });
+
+    test('rejects an explicitly empty narrowing rather than widening it', async () => {
+      const { toolRegistry } = await import('../dist/index.js');
+      expect(() =>
+        toolRegistry.get_download_limits.schema.parse({ sources: [] }),
+      ).toThrow();
+    });
   });
 
   test('should handle McpServer instantiation exceptions gracefully', async () => {
@@ -365,7 +398,12 @@ describe('Tool Handlers (Direct)', () => {
 
        const response = await handler(validatedArgs);
 
-       expect(mockGetDownloadLimits).toHaveBeenCalledWith({ signal: undefined });
+       // Per-source since #107: the tool now takes an optional `sources`
+       // narrowing, and the API layer receives it alongside the signal.
+       expect(mockGetDownloadLimits).toHaveBeenCalledWith(
+         { sources: undefined },
+         { signal: undefined },
+       );
        expect(response).toEqual(mockResult);
 
        const error = new Error('Limits Error');

--- a/__tests__/python/test_optional_dependencies.py
+++ b/__tests__/python/test_optional_dependencies.py
@@ -289,9 +289,14 @@ def test_core_only_bridge_starts_and_completes_offline_search():
         import python_bridge as bridge
 
         class OfflineRouter:
+            config = None
+
             async def search(self, query, source="auto", **kwargs):
                 assert query == "offline boundary probe"
                 return []
+
+            def intended_source(self, source="auto"):
+                return "libgen"
 
             async def close(self):
                 return None
@@ -327,7 +332,12 @@ def test_core_only_bridge_starts_and_completes_offline_search():
     assert result.returncode == 0, result.stderr
     envelope = json.loads(result.stdout)
     payload = json.loads(envelope["content"][0]["text"])
-    assert payload == {"books": [], "sources_used": []}
+    assert payload["books"] == []
+    # The #101 routing report is built from configuration alone, so a
+    # core-only install must still receive it.
+    assert payload["routing"]["served_by"] == []
+    assert payload["routing"]["fell_back"] is False
+    assert set(payload["routing"]["sources"]) == {"annas_archive", "libgen", "zlibrary"}
 
 
 @pytest.mark.asyncio

--- a/__tests__/python/test_python_bridge.py
+++ b/__tests__/python/test_python_bridge.py
@@ -371,34 +371,22 @@ class TestProfileEndpoints:
         assert result[0]["id"] == "12345"
 
     @pytest.mark.asyncio
-    async def test_get_download_limits(self, patch_eapi_client):
-        """Real numbers, from the field names the EAPI actually sends."""
-        result = await get_download_limits()
-        assert result["daily_limit"] == 10
-        assert result["daily_remaining"] == 7
-        assert result["downloads_today"] == 3
-        assert result["is_premium"] is False
+    async def test_get_download_limits(self, patch_eapi_client, monkeypatch):
+        """Real numbers, from the field names the EAPI actually sends.
 
-    @pytest.mark.asyncio
-    async def test_get_download_limits_clamps_at_zero(self, patch_eapi_client):
-        """The server counts a download when issued and can exceed the cap."""
-        patch_eapi_client.get_profile = AsyncMock(
-            return_value={"user": {"downloads_today": 12, "downloads_limit": 10}}
-        )
-        result = await get_download_limits()
-        assert result["daily_remaining"] == 0
-
-    @pytest.mark.asyncio
-    async def test_get_download_limits_reports_unknown_if_the_shape_changes(
-        self, patch_eapi_client
-    ):
-        """A renamed field must degrade to 'unknown', not to a wrong number."""
-        patch_eapi_client.get_profile = AsyncMock(
-            return_value={"user": {"something_else": 5}}
-        )
-        result = await get_download_limits()
-        assert result["daily_limit"] == "unknown"
-        assert result["daily_remaining"] == "unknown"
+        Per-source since #107, so the numbers live under the Z-Library entry
+        rather than at top level — a tool whose name does not say 'Z-Library'
+        must not answer as though it did. The full per-source contract is
+        covered in test_routing_contract.py.
+        """
+        monkeypatch.setenv("ZLIBRARY_EMAIL", "reader@example.com")
+        monkeypatch.setenv("ZLIBRARY_PASSWORD", "hunter2")
+        entry = (await get_download_limits(sources=["zlibrary"]))["sources"]["zlibrary"]
+        assert entry["daily_limit"]["state"] == "known"
+        assert entry["daily_limit"]["total"] == 10
+        assert entry["daily_limit"]["remaining"] == 7
+        assert entry["daily_limit"]["used"] == 3
+        assert entry["details"]["is_premium"] is False
 
 
 # --- Tests for get_book_metadata_complete (EAPI-based) ---
@@ -540,11 +528,14 @@ class TestDownloadBook:
         )
         mocker.patch("httpx.AsyncClient", Client)
 
-        result = await python_bridge._fetch_from_source(
+        result, provenance = await python_bridge._fetch_from_source(
             {"md5": expected_md5.upper(), "source": "libgen"}, str(tmp_path)
         )
 
         assert Path(result).read_bytes() == good_body
+        # The mirror that served the bytes is the second one, and the caller
+        # must be able to see that without reading stderr (#101).
+        assert provenance["source"] == "libgen"
         assert Path(result).suffix == ".pdf"
         assert yielded == ["li", "vg"]
         assert preexisting.read_bytes() == b"keep"
@@ -581,7 +572,7 @@ class TestDownloadBook:
             new=AsyncMock(return_value=str(raw_path)),
         )
 
-        result = await python_bridge._fetch_from_source(
+        result, _provenance = await python_bridge._fetch_from_source(
             {"md5": digest, "source": "libgen"}, str(tmp_path)
         )
 
@@ -1009,11 +1000,12 @@ class TestDownloadBook:
         )
         mocker.patch("httpx.AsyncClient", Client)
 
-        result = await python_bridge._fetch_from_source(
+        result, provenance = await python_bridge._fetch_from_source(
             {"md5": digest, "source": "auto"}, str(tmp_path)
         )
 
         assert Path(result).read_bytes() == good_body
+        assert provenance["source"] == "annas_archive"
         assert attempted == ["libgen.example", "annas.example"]
 
     @pytest.mark.asyncio
@@ -1292,7 +1284,7 @@ class TestDownloadBook:
         final_path.write_bytes(b"existing artifact")
         mocker.patch(
             "python_bridge._fetch_from_source",
-            new=AsyncMock(return_value=str(owned)),
+            new=AsyncMock(return_value=(str(owned), {})),
         )
 
         with pytest.raises(FileExistsError) as excinfo:
@@ -1326,7 +1318,7 @@ class TestDownloadBook:
         final_path.write_bytes(body)
         mocker.patch(
             "python_bridge._fetch_from_source",
-            new=AsyncMock(return_value=str(owned)),
+            new=AsyncMock(return_value=(str(owned), {})),
         )
 
         result = await download_book(
@@ -1358,7 +1350,7 @@ class TestDownloadBook:
         assert final_path.stat().st_size == owned.stat().st_size
         mocker.patch(
             "python_bridge._fetch_from_source",
-            new=AsyncMock(return_value=str(owned)),
+            new=AsyncMock(return_value=(str(owned), {})),
         )
 
         with pytest.raises(FileExistsError):
@@ -1640,6 +1632,9 @@ asyncio.run(python_bridge.main())
             yield SimpleNamespace(
                 url="https://cdn.example/book",
                 source=SimpleNamespace(value="annas_archive"),
+                route="fast_download",
+                mirror="annas-archive.gl",
+                host="cdn.example",
             )
 
         router = SimpleNamespace(iter_download_candidates=candidates)
@@ -2111,7 +2106,7 @@ asyncio.run(python_bridge.main())
         )
         fetch = mocker.patch(
             "python_bridge._fetch_from_source",
-            new=AsyncMock(return_value=str(raw_path)),
+            new=AsyncMock(return_value=(str(raw_path), {})),
         )
         mocker.patch(
             "python_bridge.create_unified_filename", return_value="libgen-book.pdf"
@@ -2140,7 +2135,7 @@ asyncio.run(python_bridge.main())
         raw_path.write_bytes(b"PK\x03\x04mimetypeapplication/epub+zip")
         mocker.patch(
             "python_bridge._fetch_from_source",
-            new=AsyncMock(return_value=str(raw_path)),
+            new=AsyncMock(return_value=(str(raw_path), {})),
         )
 
         async def process_real_boundary(file_path_str, **_kwargs):
@@ -2179,7 +2174,7 @@ asyncio.run(python_bridge.main())
         raw_path.write_bytes(b"MOBI book bytes")
         mocker.patch(
             "python_bridge._fetch_from_source",
-            new=AsyncMock(return_value=str(raw_path)),
+            new=AsyncMock(return_value=(str(raw_path), {})),
         )
         process = mocker.patch(
             "python_bridge.process_document",
@@ -2450,8 +2445,16 @@ class TestRequiresEapiClient:
     def test_zlibrary_functions_require_eapi(self):
         from lib import python_bridge
 
-        for fn in ("search", "full_text_search", "get_download_limits"):
+        for fn in ("search", "full_text_search", "get_download_history"):
             assert python_bridge._requires_eapi_client(fn, {}) is True
+
+    def test_per_source_download_limits_do_not_force_a_login(self):
+        """#107: LibGen and Anna's answer from configuration. Z-Library's own
+        entry logs in lazily, so its outage costs one entry rather than the
+        whole tool."""
+        from lib import python_bridge
+
+        assert python_bridge._requires_eapi_client("get_download_limits", {}) is False
 
     def test_local_and_multi_source_functions_do_not(self):
         from lib import python_bridge
@@ -2495,7 +2498,7 @@ class TestLibgenDownloadNeedsNoZlibraryLogin:
         raw.write_bytes(b"%PDF-1.4 fake body")
 
         async def fake_fetch(book_details, output_dir):
-            return str(raw)
+            return str(raw), {}
 
         async def dead_eapi(*args, **kwargs):
             raise RuntimeError("EAPI client must not be touched on this path")

--- a/__tests__/python/test_routing_contract.py
+++ b/__tests__/python/test_routing_contract.py
@@ -386,6 +386,60 @@ class TestPerSourceDownloadLimits:
         assert "EAPI login failed" in zlibrary["note"]
 
     @pytest.mark.asyncio
+    async def test_initialization_failure_marks_zlibrary_unavailable(
+        self, monkeypatch, zlibrary_credentials
+    ):
+        """A rejected login means no advertised Z-Library route is usable."""
+        monkeypatch.setattr(
+            python_bridge,
+            "initialize_eapi_client",
+            AsyncMock(side_effect=RuntimeError("credentials rejected")),
+        )
+
+        entry = (await python_bridge.get_download_limits(sources=["zlibrary"]))[
+            "sources"
+        ]["zlibrary"]
+
+        assert entry["available"] is False
+        assert entry["routes"] == []
+        assert entry["daily_limit"]["state"] == LIMIT_NOT_APPLICABLE
+        assert entry["note"] == (
+            "Z-Library initialization failed: RuntimeError: credentials rejected"
+        )
+        assert entry["details"] == {
+            "stage": "initialization",
+            "error": "RuntimeError: credentials rejected",
+        }
+
+    @pytest.mark.asyncio
+    async def test_profile_failure_keeps_authenticated_routes_available(
+        self, monkeypatch, zlibrary_credentials
+    ):
+        """A later quota lookup failure does not undo a working login."""
+        eapi = SimpleNamespace(
+            get_profile=AsyncMock(side_effect=RuntimeError("profile unavailable"))
+        )
+        monkeypatch.setattr(python_bridge, "_eapi_client", eapi)
+        monkeypatch.setattr(
+            python_bridge, "get_eapi_client", AsyncMock(return_value=eapi)
+        )
+
+        entry = (await python_bridge.get_download_limits(sources=["zlibrary"]))[
+            "sources"
+        ]["zlibrary"]
+
+        assert entry["available"] is True
+        assert entry["routes"] == ["search", "download"]
+        assert entry["daily_limit"]["state"] == LIMIT_UNKNOWN
+        assert entry["note"] == (
+            "Z-Library profile lookup failed: RuntimeError: profile unavailable"
+        )
+        assert entry["details"] == {
+            "stage": "profile",
+            "error": "RuntimeError: profile unavailable",
+        }
+
+    @pytest.mark.asyncio
     async def test_unkeyed_annas_reports_search_only_without_erroring(self):
         entry = (await python_bridge.get_download_limits(sources=["annas"]))["sources"][
             "annas_archive"

--- a/__tests__/python/test_routing_contract.py
+++ b/__tests__/python/test_routing_contract.py
@@ -1,0 +1,506 @@
+"""The source/route reporting contract decided on #96, built by #101 and #107.
+
+Three surfaces, one contract:
+
+- `search_multi_source` carries a `routing` block of purely local facts;
+- acquisition returns nested `provenance` naming what actually served the file;
+- `get_download_limits` reports every source, and costs a round-trip only for
+  the source that has one.
+
+The test that matters most is
+`test_a_fallback_to_another_source_is_visible_in_the_response`. #74 fixed the
+routing half of that bug and left the reporting half open: a caller could ask
+for Anna's, receive LibGen, and have nothing in the response say so.
+"""
+
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "lib"))
+)
+
+import python_bridge  # noqa: E402
+from lib.sources.capabilities import (  # noqa: E402
+    LIMIT_KNOWN,
+    LIMIT_NONE,
+    LIMIT_NOT_APPLICABLE,
+    LIMIT_UNKNOWN,
+)
+from lib.sources.config import SourceConfig  # noqa: E402
+from lib.sources.models import (  # noqa: E402
+    DownloadResult,
+    SourceType,
+    UnifiedBookResult,
+)
+from lib.sources.router import SourceRouter  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def isolated_environment(monkeypatch):
+    """No credentials and no cached router leak between tests."""
+    for name in ("ZLIBRARY_EMAIL", "ZLIBRARY_PASSWORD", "ANNAS_SECRET_KEY"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(python_bridge, "_source_router", None)
+    monkeypatch.setattr(python_bridge, "_eapi_client", None)
+
+
+@pytest.fixture
+def zlibrary_credentials(monkeypatch):
+    monkeypatch.setenv("ZLIBRARY_EMAIL", "reader@example.com")
+    monkeypatch.setenv("ZLIBRARY_PASSWORD", "hunter2")
+
+
+def book(md5: str, source: SourceType) -> UnifiedBookResult:
+    return UnifiedBookResult(md5=md5, title="A Book", source=source)
+
+
+def install_router(monkeypatch, results, config=None):
+    """Install a real SourceRouter whose adapters are replaced by a stub search.
+
+    Real, not a SimpleNamespace: `routing.fell_back` is computed from the
+    router's own idea of which provider it meant to reach, so a fake that
+    invents that answer would test nothing.
+    """
+    router = SourceRouter(config or SourceConfig())
+    monkeypatch.setattr(router, "search", AsyncMock(return_value=results))
+    monkeypatch.setattr(python_bridge, "_source_router", router)
+    return router
+
+
+class TestRoutingBlock:
+    @pytest.mark.asyncio
+    async def test_a_fallback_to_another_source_is_visible_in_the_response(
+        self, monkeypatch
+    ):
+        """Asking for Anna's and receiving LibGen must show up in `routing`.
+
+        This is the bug the whole contract exists to prevent. `sources_used`
+        was derived from results, so a substitution was indistinguishable from
+        a direct hit — the reporting half of #74.
+        """
+        install_router(monkeypatch, [book("a" * 32, SourceType.LIBGEN)])
+
+        result = await python_bridge.search_multi_source("hegel", source="annas")
+
+        routing = result["routing"]
+        assert routing["requested"] == "annas"
+        assert routing["served_by"] == ["libgen"]
+        assert routing["fell_back"] is True
+
+    @pytest.mark.asyncio
+    async def test_auto_served_by_its_first_choice_is_not_a_fallback(self, monkeypatch):
+        install_router(
+            monkeypatch,
+            [book("b" * 32, SourceType.ANNAS_ARCHIVE)],
+            SourceConfig(annas_secret_key="k"),
+        )
+
+        result = await python_bridge.search_multi_source("hegel", source="auto")
+
+        assert result["routing"]["served_by"] == ["annas_archive"]
+        assert result["routing"]["fell_back"] is False
+
+    @pytest.mark.asyncio
+    async def test_auto_falling_past_its_first_choice_is_a_fallback(self, monkeypatch):
+        """With a key, `auto` means Anna's first. LibGen answering is a
+        substitution, and the caller who asked for `auto` still gets told."""
+        install_router(
+            monkeypatch,
+            [book("c" * 32, SourceType.LIBGEN)],
+            SourceConfig(annas_secret_key="k"),
+        )
+
+        result = await python_bridge.search_multi_source("hegel", source="auto")
+
+        assert result["routing"]["fell_back"] is True
+
+    @pytest.mark.asyncio
+    async def test_auto_without_a_key_prefers_libgen_and_reports_no_fallback(
+        self, monkeypatch
+    ):
+        install_router(monkeypatch, [book("d" * 32, SourceType.LIBGEN)])
+
+        result = await python_bridge.search_multi_source("hegel", source="auto")
+
+        assert result["routing"]["fell_back"] is False
+
+    @pytest.mark.asyncio
+    async def test_no_results_is_not_reported_as_a_fallback(self, monkeypatch):
+        """Nothing served means nothing was substituted; calling that a
+        fallback would invent an event that did not happen."""
+        install_router(monkeypatch, [])
+
+        result = await python_bridge.search_multi_source("hegel", source="annas")
+
+        assert result["books"] == []
+        assert result["routing"]["served_by"] == []
+        assert result["routing"]["fell_back"] is False
+
+    @pytest.mark.asyncio
+    async def test_routing_is_nested_and_cannot_collide_with_book_fields(
+        self, monkeypatch
+    ):
+        """`**r.extra` is spread into each book dict, so a source-supplied
+        `source` or `size` would collide with a flat contract field (#96)."""
+        result_with_extra = UnifiedBookResult(
+            md5="e" * 32,
+            title="A Book",
+            source=SourceType.LIBGEN,
+            size="4 MB",
+            extra={"also_available_on": ["lgli"]},
+        )
+        install_router(monkeypatch, [result_with_extra])
+
+        result = await python_bridge.search_multi_source("hegel", source="libgen")
+
+        assert set(result) == {"books", "routing"}
+        assert result["books"][0]["source"] == "libgen"
+        assert result["books"][0]["size"] == "4 MB"
+        assert result["books"][0]["also_available_on"] == ["lgli"]
+
+    @pytest.mark.asyncio
+    async def test_sources_used_is_superseded_by_served_by(self, monkeypatch):
+        """#96 supersedes it: derived from results, it could not show a
+        fallback, which was the one thing callers needed from it."""
+        install_router(monkeypatch, [book("f" * 32, SourceType.LIBGEN)])
+
+        result = await python_bridge.search_multi_source("hegel", source="libgen")
+
+        assert "sources_used" not in result
+
+    @pytest.mark.asyncio
+    async def test_every_source_is_described_symmetrically(self, monkeypatch):
+        install_router(monkeypatch, [])
+
+        sources = (await python_bridge.search_multi_source("hegel"))["routing"][
+            "sources"
+        ]
+
+        assert set(sources) == {"annas_archive", "libgen", "zlibrary"}
+        shapes = {tuple(sorted(entry)) for entry in sources.values()}
+        assert len(shapes) == 1, sources
+
+    @pytest.mark.asyncio
+    async def test_routing_costs_no_network_call(self, monkeypatch):
+        """The inline half of the contract is local by definition (#96)."""
+        install_router(monkeypatch, [])
+        monkeypatch.setattr(
+            python_bridge,
+            "initialize_eapi_client",
+            AsyncMock(side_effect=AssertionError("routing must not log in")),
+        )
+
+        result = await python_bridge.search_multi_source("hegel")
+
+        assert result["routing"]["sources"]["zlibrary"]["daily_limit"]["state"] == (
+            LIMIT_NOT_APPLICABLE
+        )
+
+
+class TestPerSourceDownloadLimits:
+    @pytest.mark.asyncio
+    async def test_a_libgen_only_question_makes_no_eapi_call(self, monkeypatch):
+        """The whole point of the `sources` parameter (#107). A LibGen answer
+        is knowable from configuration, so paying for a Z-Library profile
+        fetch to produce it buys a symmetry nobody benefits from."""
+        monkeypatch.setattr(
+            python_bridge,
+            "initialize_eapi_client",
+            AsyncMock(side_effect=AssertionError("EAPI login attempted")),
+        )
+        monkeypatch.setattr(
+            python_bridge,
+            "get_eapi_client",
+            AsyncMock(side_effect=AssertionError("EAPI client requested")),
+        )
+
+        result = await python_bridge.get_download_limits(sources=["libgen"])
+
+        assert result["requested"] == ["libgen"]
+        assert set(result["sources"]) == {"libgen"}
+        assert result["sources"]["libgen"]["daily_limit"]["state"] == LIMIT_NONE
+
+    @pytest.mark.asyncio
+    async def test_the_dispatcher_does_not_force_a_login_for_this_tool(self):
+        """Z-Library's entry logs in lazily and degrades to its own `unknown`,
+        so an auth outage costs one entry rather than the whole tool."""
+        assert python_bridge._requires_eapi_client("get_download_limits", {}) is False
+
+    @pytest.mark.asyncio
+    async def test_every_source_is_reported_by_default(self, monkeypatch):
+        result = await python_bridge.get_download_limits()
+
+        assert result["requested"] == ["annas_archive", "libgen", "zlibrary"]
+        assert set(result["sources"]) == {"annas_archive", "libgen", "zlibrary"}
+
+    @pytest.mark.asyncio
+    async def test_the_three_limit_states_are_never_collapsed(self, monkeypatch):
+        """No limit exists / not knowable here / a concrete number."""
+        result = await python_bridge.get_download_limits()
+        states = {
+            name: entry["daily_limit"]["state"]
+            for name, entry in result["sources"].items()
+        }
+
+        assert states["libgen"] == LIMIT_NONE
+        assert states["annas_archive"] == LIMIT_NOT_APPLICABLE
+        assert states["zlibrary"] == LIMIT_NOT_APPLICABLE
+
+    @pytest.mark.asyncio
+    async def test_zlibrary_reports_concrete_numbers_from_the_profile(
+        self, monkeypatch, zlibrary_credentials
+    ):
+        eapi = SimpleNamespace(
+            get_profile=AsyncMock(
+                return_value={
+                    "user": {
+                        "downloads_today": 3,
+                        "downloads_limit": 10,
+                        "isPremium": 0,
+                    }
+                }
+            )
+        )
+        monkeypatch.setattr(python_bridge, "_eapi_client", eapi)
+        monkeypatch.setattr(
+            python_bridge, "get_eapi_client", AsyncMock(return_value=eapi)
+        )
+
+        entry = (await python_bridge.get_download_limits(sources=["zlibrary"]))[
+            "sources"
+        ]["zlibrary"]
+
+        assert entry["daily_limit"]["state"] == LIMIT_KNOWN
+        assert entry["daily_limit"]["total"] == 10
+        assert entry["daily_limit"]["used"] == 3
+        assert entry["daily_limit"]["remaining"] == 7
+        assert entry["details"]["is_premium"] is False
+
+    @pytest.mark.asyncio
+    async def test_zlibrary_remaining_is_clamped_at_zero(
+        self, monkeypatch, zlibrary_credentials
+    ):
+        """The server counts a download when issued and can exceed the cap."""
+        eapi = SimpleNamespace(
+            get_profile=AsyncMock(
+                return_value={"user": {"downloads_today": 12, "downloads_limit": 10}}
+            )
+        )
+        monkeypatch.setattr(python_bridge, "_eapi_client", eapi)
+        monkeypatch.setattr(
+            python_bridge, "get_eapi_client", AsyncMock(return_value=eapi)
+        )
+
+        entry = (await python_bridge.get_download_limits(sources=["zlibrary"]))[
+            "sources"
+        ]["zlibrary"]
+
+        assert entry["daily_limit"]["remaining"] == 0
+
+    @pytest.mark.asyncio
+    async def test_a_known_cap_with_an_unknown_spend_reports_no_remainder(
+        self, monkeypatch, zlibrary_credentials
+    ):
+        """The cap is known and the spend is not, so the remainder is not
+        derivable. Reporting the full cap would fabricate a number."""
+        eapi = SimpleNamespace(
+            get_profile=AsyncMock(return_value={"user": {"downloads_limit": 10}})
+        )
+        monkeypatch.setattr(python_bridge, "_eapi_client", eapi)
+        monkeypatch.setattr(
+            python_bridge, "get_eapi_client", AsyncMock(return_value=eapi)
+        )
+
+        limit = (await python_bridge.get_download_limits(sources=["zlibrary"]))[
+            "sources"
+        ]["zlibrary"]["daily_limit"]
+
+        assert limit["state"] == LIMIT_KNOWN
+        assert limit["total"] == 10
+        assert limit["used"] is None
+        assert limit["remaining"] is None
+        assert "downloads_today" in limit["note"]
+
+    @pytest.mark.asyncio
+    async def test_a_renamed_profile_field_degrades_to_unknown_not_a_number(
+        self, monkeypatch, zlibrary_credentials
+    ):
+        eapi = SimpleNamespace(
+            get_profile=AsyncMock(return_value={"user": {"something_else": 5}})
+        )
+        monkeypatch.setattr(python_bridge, "_eapi_client", eapi)
+        monkeypatch.setattr(
+            python_bridge, "get_eapi_client", AsyncMock(return_value=eapi)
+        )
+
+        entry = (await python_bridge.get_download_limits(sources=["zlibrary"]))[
+            "sources"
+        ]["zlibrary"]
+
+        assert entry["daily_limit"]["state"] == LIMIT_UNKNOWN
+        assert entry["daily_limit"]["total"] is None
+        assert "downloads_limit" in entry["daily_limit"]["note"]
+
+    @pytest.mark.asyncio
+    async def test_a_zlibrary_outage_costs_one_entry_not_the_whole_call(
+        self, monkeypatch, zlibrary_credentials
+    ):
+        """A credential-free-by-outage Z-Library must not take LibGen's
+        answer down with it — the failure #129 fixed for search."""
+        eapi = SimpleNamespace(
+            get_profile=AsyncMock(side_effect=RuntimeError("EAPI login failed"))
+        )
+        monkeypatch.setattr(python_bridge, "_eapi_client", eapi)
+        monkeypatch.setattr(
+            python_bridge, "get_eapi_client", AsyncMock(return_value=eapi)
+        )
+
+        result = await python_bridge.get_download_limits()
+
+        assert result["sources"]["libgen"]["daily_limit"]["state"] == LIMIT_NONE
+        zlibrary = result["sources"]["zlibrary"]["daily_limit"]
+        assert zlibrary["state"] == LIMIT_UNKNOWN
+        assert "EAPI login failed" in zlibrary["note"]
+
+    @pytest.mark.asyncio
+    async def test_unkeyed_annas_reports_search_only_without_erroring(self):
+        entry = (await python_bridge.get_download_limits(sources=["annas"]))["sources"][
+            "annas_archive"
+        ]
+
+        assert entry["routes"] == ["search"]
+        assert entry["daily_limit"]["state"] == LIMIT_NOT_APPLICABLE
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_source_is_named_rather_than_ignored(self):
+        with pytest.raises(ValueError, match="Unknown source 'gutenberg'"):
+            await python_bridge.get_download_limits(sources=["gutenberg"])
+
+    @pytest.mark.asyncio
+    async def test_entries_stay_symmetric_across_sources(
+        self, monkeypatch, zlibrary_credentials
+    ):
+        eapi = SimpleNamespace(
+            get_profile=AsyncMock(
+                return_value={"user": {"downloads_today": 1, "downloads_limit": 10}}
+            )
+        )
+        monkeypatch.setattr(python_bridge, "_eapi_client", eapi)
+        monkeypatch.setattr(
+            python_bridge, "get_eapi_client", AsyncMock(return_value=eapi)
+        )
+
+        entries = (await python_bridge.get_download_limits())["sources"]
+
+        shapes = {tuple(sorted(entry)) for entry in entries.values()}
+        assert len(shapes) == 1, entries
+
+
+class TestProvenance:
+    @pytest.mark.asyncio
+    async def test_source_acquisition_returns_the_mirror_and_cdn_host(
+        self, tmp_path, monkeypatch
+    ):
+        """Before #101 these went to `logger.warning` on stderr and the caller
+        never saw which of three mirrors had answered (found on #98)."""
+
+        async def candidates(_md5, source):
+            yield DownloadResult(
+                url="https://libgen.vg/get.php?md5=f&key=k",
+                source=SourceType.LIBGEN,
+                route="get.php",
+                mirror="vg",
+                host="cdn3.booksdl.test",
+            )
+
+        raw = tmp_path / ".source-owned.pdf"
+        raw.write_bytes(b"%PDF-1.7 bytes")
+        monkeypatch.setattr(
+            python_bridge,
+            "get_source_router",
+            AsyncMock(
+                return_value=SimpleNamespace(iter_download_candidates=candidates)
+            ),
+        )
+        monkeypatch.setattr(
+            python_bridge,
+            "_download_url_to_file",
+            AsyncMock(return_value=str(raw)),
+        )
+
+        _path, provenance = await python_bridge._fetch_from_source(
+            {"md5": "f" * 32, "source": "libgen"}, str(tmp_path)
+        )
+
+        assert provenance == {
+            "source": "libgen",
+            "route": "get.php",
+            "mirror": "vg",
+            "host": "libgen.vg",
+        }
+
+    @pytest.mark.asyncio
+    async def test_provenance_is_nested_on_the_download_result(
+        self, tmp_path, monkeypatch
+    ):
+        raw = tmp_path / ".source-owned.pdf"
+        raw.write_bytes(b"%PDF-1.7 bytes")
+        monkeypatch.setattr(
+            python_bridge,
+            "_fetch_from_source",
+            AsyncMock(
+                return_value=(
+                    str(raw),
+                    {
+                        "source": "libgen",
+                        "route": "get.php",
+                        "mirror": "li",
+                        "host": "cdn1.booksdl.test",
+                    },
+                )
+            ),
+        )
+
+        result = await python_bridge.download_book(
+            book_details={
+                "md5": "f" * 32,
+                "source": "libgen",
+                "title": "A Book",
+                "extension": "pdf",
+            },
+            output_dir=str(tmp_path),
+        )
+
+        assert result["provenance"]["mirror"] == "li"
+        assert result["provenance"]["host"] == "cdn1.booksdl.test"
+        # Flat keys were the smaller diff and the wrong choice (#96).
+        assert "mirror" not in result
+        assert "host" not in result
+
+    @pytest.mark.asyncio
+    async def test_provenance_describes_the_transfer_not_the_content(
+        self, tmp_path, monkeypatch
+    ):
+        """Invariant 1: no document text may ride back inside provenance."""
+        raw = tmp_path / ".source-owned.pdf"
+        raw.write_bytes(b"%PDF-1.7 bytes")
+        monkeypatch.setattr(
+            python_bridge,
+            "_fetch_from_source",
+            AsyncMock(return_value=(str(raw), python_bridge._provenance("libgen"))),
+        )
+
+        result = await python_bridge.download_book(
+            book_details={"md5": "f" * 32, "source": "libgen", "title": "A Book"},
+            output_dir=str(tmp_path),
+        )
+
+        assert sorted(result["provenance"]) == ["host", "mirror", "route", "source"]
+        assert result["provenance"]["mirror"] is None

--- a/__tests__/python/test_routing_contract.py
+++ b/__tests__/python/test_routing_contract.py
@@ -143,6 +143,22 @@ class TestRoutingBlock:
         assert result["routing"]["served_by"] == []
         assert result["routing"]["fell_back"] is False
 
+    @pytest.mark.parametrize("count", [0, -1])
+    @pytest.mark.asyncio
+    async def test_slicing_results_does_not_erase_who_served_them(
+        self, monkeypatch, count
+    ):
+        """A successful fallback stays visible even when no book is returned."""
+        install_router(monkeypatch, [book("e" * 32, SourceType.LIBGEN)])
+
+        result = await python_bridge.search_multi_source(
+            "hegel", source="annas", count=count
+        )
+
+        assert result["books"] == []
+        assert result["routing"]["served_by"] == ["libgen"]
+        assert result["routing"]["fell_back"] is True
+
     @pytest.mark.asyncio
     async def test_routing_is_nested_and_cannot_collide_with_book_fields(
         self, monkeypatch

--- a/__tests__/python/test_source_capabilities.py
+++ b/__tests__/python/test_source_capabilities.py
@@ -133,6 +133,20 @@ class TestLimitStates:
         assert entry["routes"] == ["search", "download"]
         assert entry["daily_limit"]["state"] == LIMIT_UNKNOWN
 
+    def test_keyed_annas_on_an_untrusted_host_is_search_only(self):
+        """The report must not advertise a route the adapter rejects."""
+        entry = describe_sources(
+            SourceConfig(
+                annas_secret_key="k",
+                annas_base_url="https://annas-archive.li",
+            )
+        )[SOURCE_ANNAS]
+
+        assert entry["available"] is True
+        assert entry["routes"] == ["search"]
+        assert entry["daily_limit"]["state"] == LIMIT_NOT_APPLICABLE
+        assert "not trusted" in entry["note"]
+
     def test_a_concrete_number_is_distinguishable_from_both(self):
         limit = known_daily_limit(10, 3, 7)
         assert limit["state"] == LIMIT_KNOWN

--- a/__tests__/python/test_source_capabilities.py
+++ b/__tests__/python/test_source_capabilities.py
@@ -1,0 +1,155 @@
+"""Tests for the symmetric source-capability vocabulary (#96, #101, #107).
+
+The two rules under test are the ones a plausible refactor breaks silently:
+every source carries the same key set, and a daily limit is three-valued
+rather than nullable.
+"""
+
+import pytest
+
+from lib.sources.capabilities import (
+    KNOWN_SOURCES,
+    LIMIT_KNOWN,
+    LIMIT_NONE,
+    LIMIT_NOT_APPLICABLE,
+    LIMIT_UNKNOWN,
+    SOURCE_ANNAS,
+    SOURCE_LIBGEN,
+    SOURCE_ZLIBRARY,
+    canonical_source,
+    describe_sources,
+    known_daily_limit,
+    resolve_requested_sources,
+)
+from lib.sources.config import SourceConfig
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def no_zlibrary_credentials(monkeypatch):
+    """Default to a credential-free environment; tests opt in explicitly."""
+    monkeypatch.delenv("ZLIBRARY_EMAIL", raising=False)
+    monkeypatch.delenv("ZLIBRARY_PASSWORD", raising=False)
+
+
+@pytest.fixture
+def zlibrary_credentials(monkeypatch):
+    monkeypatch.setenv("ZLIBRARY_EMAIL", "reader@example.com")
+    monkeypatch.setenv("ZLIBRARY_PASSWORD", "hunter2")
+
+
+class TestSourceNames:
+    def test_selector_spellings_map_to_canonical_names(self):
+        """`source="annas"` and the report's `annas_archive` are one source."""
+        assert canonical_source("annas") == SOURCE_ANNAS
+        assert canonical_source("ANNAS_ARCHIVE") == SOURCE_ANNAS
+        assert canonical_source("libgen") == SOURCE_LIBGEN
+        assert canonical_source("z-library") == SOURCE_ZLIBRARY
+
+    def test_unknown_source_names_itself_and_the_alternatives(self):
+        with pytest.raises(ValueError, match="Unknown source 'gutenberg'"):
+            canonical_source("gutenberg")
+
+    def test_omitted_selection_means_every_source(self):
+        assert resolve_requested_sources(None) == list(KNOWN_SOURCES)
+
+    def test_selection_is_deduplicated_and_ordered(self):
+        assert resolve_requested_sources(["libgen", "annas", "libgen"]) == [
+            SOURCE_ANNAS,
+            SOURCE_LIBGEN,
+        ]
+
+    def test_explicitly_empty_selection_is_rejected_not_widened(self):
+        """Widening 'nothing' to 'everything' would spend the round-trip the
+        caller was trying to avoid."""
+        with pytest.raises(ValueError, match="at least one source"):
+            resolve_requested_sources([])
+
+
+class TestSymmetry:
+    """Invariant 4: report, never rank. No source gets a field the others lack."""
+
+    def test_every_source_carries_the_same_key_set(self, zlibrary_credentials):
+        entries = describe_sources(SourceConfig(annas_secret_key="k"))
+        assert set(entries) == set(KNOWN_SOURCES)
+        shapes = {name: sorted(entry) for name, entry in entries.items()}
+        assert len(set(map(tuple, shapes.values()))) == 1, shapes
+        assert shapes[SOURCE_LIBGEN] == [
+            "available",
+            "daily_limit",
+            "note",
+            "routes",
+        ]
+
+    def test_key_set_is_identical_with_and_without_credentials(self):
+        """An unconfigured source reports the same fields, not fewer."""
+        keyed = describe_sources(SourceConfig(annas_secret_key="k"))
+        unkeyed = describe_sources(SourceConfig(annas_secret_key=""))
+        assert sorted(keyed[SOURCE_ANNAS]) == sorted(unkeyed[SOURCE_ANNAS])
+        for entry in list(keyed.values()) + list(unkeyed.values()):
+            assert sorted(entry["daily_limit"]) == [
+                "note",
+                "remaining",
+                "state",
+                "total",
+                "used",
+            ]
+
+
+class TestLimitStates:
+    """Three facts, three states. Collapsing them onto null is the bug."""
+
+    def test_libgen_reports_no_limit_rather_than_unknown(self):
+        entry = describe_sources(SourceConfig())[SOURCE_LIBGEN]
+        assert entry["daily_limit"]["state"] == LIMIT_NONE
+        assert entry["daily_limit"]["total"] is None
+        assert entry["routes"] == ["search", "download"]
+
+    def test_zlibrary_limit_is_unknown_locally_and_says_what_would_answer(
+        self, zlibrary_credentials
+    ):
+        entry = describe_sources(SourceConfig())[SOURCE_ZLIBRARY]
+        assert entry["available"] is True
+        assert entry["daily_limit"]["state"] == LIMIT_UNKNOWN
+        assert "get_download_limits" in entry["daily_limit"]["note"]
+
+    def test_zlibrary_without_credentials_is_unavailable_not_unknown(self):
+        entry = describe_sources(SourceConfig())[SOURCE_ZLIBRARY]
+        assert entry["available"] is False
+        assert entry["routes"] == []
+        assert entry["daily_limit"]["state"] == LIMIT_NOT_APPLICABLE
+
+    def test_unkeyed_annas_is_search_only_and_still_available(self):
+        """#107: search-only, reported without erroring."""
+        entry = describe_sources(SourceConfig(annas_secret_key=""))[SOURCE_ANNAS]
+        assert entry["available"] is True
+        assert entry["routes"] == ["search"]
+        assert entry["daily_limit"]["state"] == LIMIT_NOT_APPLICABLE
+        assert "ANNAS_SECRET_KEY" in entry["note"]
+
+    def test_keyed_annas_gains_the_download_route(self):
+        entry = describe_sources(SourceConfig(annas_secret_key="k"))[SOURCE_ANNAS]
+        assert entry["routes"] == ["search", "download"]
+        assert entry["daily_limit"]["state"] == LIMIT_UNKNOWN
+
+    def test_a_concrete_number_is_distinguishable_from_both(self):
+        limit = known_daily_limit(10, 3, 7)
+        assert limit["state"] == LIMIT_KNOWN
+        assert (limit["total"], limit["used"], limit["remaining"]) == (10, 3, 7)
+
+    def test_the_four_states_are_distinct(self):
+        assert len({LIMIT_NONE, LIMIT_KNOWN, LIMIT_UNKNOWN, LIMIT_NOT_APPLICABLE}) == 4
+
+
+class TestNoNetwork:
+    def test_describing_sources_opens_no_connection(self, monkeypatch):
+        """`routing` rides along with every search, so it must stay local."""
+        import socket
+
+        def refuse(*args, **kwargs):
+            raise AssertionError("describe_sources must not touch the network")
+
+        monkeypatch.setattr(socket, "socket", refuse)
+        monkeypatch.setattr(socket, "getaddrinfo", refuse)
+        assert set(describe_sources(SourceConfig())) == set(KNOWN_SOURCES)

--- a/__tests__/types/download-book-result.test.ts
+++ b/__tests__/types/download-book-result.test.ts
@@ -1,0 +1,21 @@
+import type { DownloadBookResult } from '../../src/lib/zlibrary-api.js';
+
+const result: DownloadBookResult = {
+  file_path: '/tmp/book.pdf',
+  processed_file_path: null,
+  provenance: {
+    source: 'libgen',
+    route: 'get.php',
+    mirror: null,
+    host: null,
+  },
+};
+
+const mirror: string | null = result.provenance.mirror;
+
+// Provenance follows the Python bridge's `_provenance` contract: each value
+// may be absent for a real transfer and is represented as null, not invented.
+// @ts-expect-error host is nullable
+const hostMustNotBeString: string = result.provenance.host;
+
+export { hostMustNotBeString, mirror, result };

--- a/__tests__/zlibrary-api.test.js
+++ b/__tests__/zlibrary-api.test.js
@@ -606,7 +606,26 @@ describe('Z-Library API', () => {
         }), expect.objectContaining({ label: expect.any(String) }));
     });
 
-    test('should omit the key entirely when no narrowing is given', async () => {
+    test('should preserve a legacy one-argument cancellation option', async () => {
+        mockGetManagedPythonPath.mockResolvedValue('/fake/python');
+        const payload = JSON.stringify({ requested: [], sources: {} });
+        mockRunPythonBridge.mockResolvedValueOnce([
+            JSON.stringify({ content: [{ type: 'text', text: payload }] }),
+        ]);
+        const controller = new AbortController();
+
+        await zlibApi.getDownloadLimits({ signal: controller.signal });
+
+        expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
+            scriptPath: EXPECTED_SCRIPT_PATH,
+            args: ['get_download_limits', JSON.stringify({})],
+        }), expect.objectContaining({
+            label: expect.any(String),
+            signal: controller.signal,
+        }));
+    });
+
+    test('should preserve an explicit empty narrowing for bridge validation', async () => {
         mockGetManagedPythonPath.mockResolvedValue('/fake/python');
         const payload = JSON.stringify({ requested: [], sources: {} });
         mockRunPythonBridge.mockResolvedValueOnce([
@@ -615,12 +634,11 @@ describe('Z-Library API', () => {
 
         await zlibApi.getDownloadLimits({ sources: [] });
 
-        // An explicit empty list is the bridge's "you asked about nothing"
-        // error case; the API layer treats it as "no narrowing given" rather
-        // than sending a request that can only fail.
+        // `[]` is distinct from omitting `sources`: the bridge rejects an
+        // explicit request about no sources instead of widening it to all.
         expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
             scriptPath: EXPECTED_SCRIPT_PATH,
-            args: ['get_download_limits', JSON.stringify({})]
+            args: ['get_download_limits', JSON.stringify({ sources: [] })]
         }), expect.objectContaining({ label: expect.any(String) }));
     });
   });

--- a/__tests__/zlibrary-api.test.js
+++ b/__tests__/zlibrary-api.test.js
@@ -364,7 +364,10 @@ describe('Z-Library API', () => {
 
     // Updated for Spec v2.1: Uses bookDetails, expects absolute path, no processed_file_path
     test('should call Python bridge with correct args (no RAG)', async () => {
-        const pythonResult_dl1 = { file_path: '/abs/path/to/downloads/Success Book.epub' }; // Unique result var
+        const pythonResult_dl1 = {
+            file_path: '/abs/path/to/downloads/Success Book.epub',
+            provenance: { source: 'zlibrary', route: 'eapi', mirror: null, host: null },
+        }; // Unique result var
         mockGetManagedPythonPath.mockResolvedValue('/fake/python');
         // Corrected Mock: Simulate python printing the JSON string of the MCP response structure
         const mockPythonResultString_dl1 = JSON.stringify(pythonResult_dl1);
@@ -387,7 +390,8 @@ describe('Z-Library API', () => {
             })]
         }), expect.objectContaining({ label: expect.any(String) }));
         expect(result).toEqual({
-            file_path: '/abs/path/to/downloads/Success Book.epub'
+            file_path: '/abs/path/to/downloads/Success Book.epub',
+            provenance: { source: 'zlibrary', route: 'eapi', mirror: null, host: null },
             // No processed_file_path expected
         });
     });
@@ -404,7 +408,8 @@ describe('Z-Library API', () => {
                 body: '/abs/path/to/processed_rag_output/RAG Book.pdf.processed.md',
                 metadata: '/abs/path/to/processed_rag_output/RAG Book.pdf.metadata.json',
                 footnotes: '/abs/path/to/processed_rag_output/RAG Book.pdf.processed_footnotes.md'
-            }
+            },
+            provenance: { source: 'zlibrary', route: 'eapi', mirror: null, host: null },
         };
         mockGetManagedPythonPath.mockResolvedValue('/fake/python');
         // Corrected Mock: Simulate python printing the JSON string of the MCP response structure
@@ -437,7 +442,8 @@ describe('Z-Library API', () => {
                 body: '/abs/path/to/processed_rag_output/RAG Book.pdf.processed.md',
                 metadata: '/abs/path/to/processed_rag_output/RAG Book.pdf.metadata.json',
                 footnotes: '/abs/path/to/processed_rag_output/RAG Book.pdf.processed_footnotes.md'
-            }
+            },
+            provenance: { source: 'zlibrary', route: 'eapi', mirror: null, host: null },
         });
     });
 
@@ -449,7 +455,8 @@ describe('Z-Library API', () => {
             metadata_file_path: null,
             stats: null,
             content_types_produced: [],
-            output_files: {}
+            output_files: {},
+            provenance: { source: 'zlibrary', route: 'eapi', mirror: null, host: null },
         };
         mockGetManagedPythonPath.mockResolvedValue('/fake/python');
         // Corrected Mock: Simulate python printing the JSON string of the MCP response structure
@@ -477,7 +484,8 @@ describe('Z-Library API', () => {
             metadata_file_path: null,
             stats: null,
             content_types_produced: [],
-            output_files: {}
+            output_files: {},
+            provenance: { source: 'zlibrary', route: 'eapi', mirror: null, host: null },
         });
     });
 
@@ -501,9 +509,44 @@ describe('Z-Library API', () => {
         expect(mockRunPythonBridge).toHaveBeenCalledTimes(1);
     });
 
+    test('should reject a bridge download result missing provenance', async () => {
+        mockGetManagedPythonPath.mockResolvedValue('/fake/python');
+        mockRunPythonBridge.mockResolvedValueOnce([
+            JSON.stringify({ content: [{ type: 'text', text: JSON.stringify({
+                file_path: '/abs/path/book.pdf',
+            }) }] }),
+        ]);
+
+        await expect(zlibApi.downloadBookToFile({ bookDetails: { id: 'missing-provenance' } }))
+            .rejects
+            .toThrow('Invalid response from Python bridge: Missing provenance.');
+    });
+
+    test('should reject a bridge download result with malformed provenance', async () => {
+        mockGetManagedPythonPath.mockResolvedValue('/fake/python');
+        mockRunPythonBridge.mockResolvedValueOnce([
+            JSON.stringify({ content: [{ type: 'text', text: JSON.stringify({
+                file_path: '/abs/path/book.pdf',
+                provenance: {
+                    source: 'libgen',
+                    route: 'get.php',
+                    mirror: null,
+                    host: 42,
+                },
+            }) }] }),
+        ]);
+
+        await expect(zlibApi.downloadBookToFile({ bookDetails: { id: 'malformed-provenance' } }))
+            .rejects
+            .toThrow('Invalid response from Python bridge: provenance.host must be a string or null.');
+    });
+
     // Updated for Spec v2.1: Uses bookDetails
     test('should throw error if processing requested and Python response missing processed_file_path key', async () => {
-        const invalidPythonResult_dl5 = { file_path: '/abs/path/book.epub' }; // Unique result var, Missing processed_file_path key
+        const invalidPythonResult_dl5 = {
+            file_path: '/abs/path/book.epub',
+            provenance: { source: 'zlibrary', route: 'eapi', mirror: null, host: null },
+        }; // Unique result var, Missing processed_file_path key
         mockGetManagedPythonPath.mockResolvedValue('/fake/python');
         // Corrected Mock: Simulate python printing the JSON string of the MCP response structure
         const mockPythonResultString_dl5 = JSON.stringify(invalidPythonResult_dl5);
@@ -783,7 +826,10 @@ describe('Z-Library API', () => {
     });
 
     test('a download gets the long budget', async () => {
-      resolveWith({ file_path: '/abs/downloads/Book.epub' });
+      resolveWith({
+        file_path: '/abs/downloads/Book.epub',
+        provenance: { source: 'zlibrary', route: 'eapi', mirror: null, host: null },
+      });
       await zlibApi.downloadBookToFile({
         bookDetails: { id: 'x', url: 'http://example.com/book/x/s', title: 'Book' },
         outputDir: './downloads',

--- a/__tests__/zlibrary-api.test.js
+++ b/__tests__/zlibrary-api.test.js
@@ -588,6 +588,41 @@ describe('Z-Library API', () => {
       await expect(zlibApi.getDownloadLimits()).rejects.toThrow(`Python bridge execution failed for get_download_limits: ${apiError.message}`);
       expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({ scriptPath: EXPECTED_SCRIPT_PATH, args: ['get_download_limits', JSON.stringify({})] }), expect.objectContaining({ label: expect.any(String) })); // Corrected script name and path
     });
+
+    // #107: `sources` is what lets a LibGen-only question skip the Z-Library
+    // profile round-trip. It has to reach the bridge to do that.
+    test('should forward an explicit source narrowing to the bridge', async () => {
+        mockGetManagedPythonPath.mockResolvedValue('/fake/python');
+        const payload = JSON.stringify({ requested: ['libgen'], sources: {} });
+        mockRunPythonBridge.mockResolvedValueOnce([
+            JSON.stringify({ content: [{ type: 'text', text: payload }] }),
+        ]);
+
+        await zlibApi.getDownloadLimits({ sources: ['libgen'] });
+
+        expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
+            scriptPath: EXPECTED_SCRIPT_PATH,
+            args: ['get_download_limits', JSON.stringify({ sources: ['libgen'] })]
+        }), expect.objectContaining({ label: expect.any(String) }));
+    });
+
+    test('should omit the key entirely when no narrowing is given', async () => {
+        mockGetManagedPythonPath.mockResolvedValue('/fake/python');
+        const payload = JSON.stringify({ requested: [], sources: {} });
+        mockRunPythonBridge.mockResolvedValueOnce([
+            JSON.stringify({ content: [{ type: 'text', text: payload }] }),
+        ]);
+
+        await zlibApi.getDownloadLimits({ sources: [] });
+
+        // An explicit empty list is the bridge's "you asked about nothing"
+        // error case; the API layer treats it as "no narrowing given" rather
+        // than sending a request that can only fail.
+        expect(mockRunPythonBridge).toHaveBeenCalledWith('python_bridge.py', expect.objectContaining({
+            scriptPath: EXPECTED_SCRIPT_PATH,
+            args: ['get_download_limits', JSON.stringify({})]
+        }), expect.objectContaining({ label: expect.any(String) }));
+    });
   });
 
   describe('processDocumentForRag', () => {

--- a/docs/api.md
+++ b/docs/api.md
@@ -260,7 +260,64 @@ Results from this tool can be downloaded. Pass a result to `download_book_to_fil
 | source | enum | No | `"auto"` | Source selection: `"auto"` (Anna's Archive if key available, else LibGen), `"annas"` (force Anna's Archive), or `"libgen"` (force LibGen) |
 | count | integer | No | `10` | Maximum number of results to return |
 
-**Returns:** JSON array of book objects with the fields `md5`, `title`, `author`, `year`, `extension`, `size`, and `source`.
+**Returns:** JSON object with `books` and `routing`.
+
+`books` is an array of book objects with the fields `md5`, `title`, `author`, `year`, `extension`, `size`, and `source`.
+
+`routing` reports what you asked for, what answered, and what each source can currently do. Every fact in it is read from configuration, so it costs no extra network request. Facts that would cost one live in `get_download_limits` instead.
+
+| Field | Meaning |
+|-------|---------|
+| `requested` | The `source` value you passed, verbatim (`"auto"`, `"annas"`, or `"libgen"`) |
+| `served_by` | Canonical names of the sources that supplied the returned books |
+| `fell_back` | `true` when the source that answered is not the one the server meant to try first |
+| `sources` | One entry per source, with the same fields for every source |
+
+`fell_back` is the reason this block exists. Ask for one source, receive another, and nothing else in the response tells you the substitution happened.
+
+Each entry in `routing.sources` has `available` (at least one route is usable now), `routes` (which of `search` and `download`), `note` (a sentence naming the constraint), and `daily_limit`. A `daily_limit` is never a bare `null`: its `state` says which of four situations you are in.
+
+| `state` | Meaning |
+|---------|---------|
+| `none` | This source imposes no daily limit. Library Genesis. |
+| `known` | The source reported its cap. `total`, `used`, and `remaining` carry the numbers it reported; a value it omitted stays `null` with the reason in `note`, never a derived guess |
+| `unknown` | A limit exists and its value is not available here. `note` says what would answer it. |
+| `not_applicable` | The source has no download route right now, so there is no quota |
+
+**Example routing block:**
+
+```json
+{
+  "requested": "annas",
+  "served_by": ["libgen"],
+  "fell_back": true,
+  "sources": {
+    "annas_archive": {
+      "available": true,
+      "routes": ["search"],
+      "note": "no ANNAS_SECRET_KEY; search only, download unavailable",
+      "daily_limit": { "state": "not_applicable", "total": null, "used": null,
+                       "remaining": null, "note": "no download route without ANNAS_SECRET_KEY" }
+    },
+    "libgen": {
+      "available": true,
+      "routes": ["search", "download"],
+      "note": "no account required; mirror li first",
+      "daily_limit": { "state": "none", "total": null, "used": null,
+                       "remaining": null, "note": "LibGen applies no daily download limit" }
+    },
+    "zlibrary": {
+      "available": true,
+      "routes": ["search", "download"],
+      "note": "credentials configured",
+      "daily_limit": { "state": "unknown", "total": null, "used": null,
+                       "remaining": null, "note": "costs an EAPI profile call; ask get_download_limits" }
+    }
+  }
+}
+```
+
+**Note:** `sources_used` was removed. It was computed from the results, so it could not distinguish a fallback from a direct hit. Read `routing.served_by` and `routing.fell_back` instead.
 
 **Note:** `download_url` is empty for Library Genesis results. The server resolves a download link only when you request the file, because a Library Genesis link expires in less than 2.5 hours.
 
@@ -410,7 +467,24 @@ This tool accepts results from `search_books` (Z-Library) and from `search_multi
 | process_for_rag | boolean | No | -- | Whether to process the document content for RAG after download |
 | processed_output_format | string | No | -- | Desired output format for RAG processing (e.g., `"text"`, `"markdown"`) |
 
-**Returns:** JSON object with `file_path` (downloaded file path). If RAG processing was requested, the response also includes `processed_file_path` (body text), `metadata_file_path`, optional `footnotes_file_path` / `endnotes_file_path` / `citations_file_path`, `content_types_produced`, `stats`, and `output_files`.
+**Returns:** JSON object with `file_path` (downloaded file path) and `provenance`. If RAG processing was requested, the response also includes `processed_file_path` (body text), `metadata_file_path`, optional `footnotes_file_path` / `endnotes_file_path` / `citations_file_path`, `content_types_produced`, `stats`, and `output_files`.
+
+`provenance` records what actually served the file. It is a nested object, not four top-level fields, because a source's own metadata is spread into the book object and a flat `source` key would collide with it silently.
+
+| Field | Meaning |
+|-------|---------|
+| `source` | Canonical name of the source that served the file |
+| `route` | The named route taken: `get.php` for Library Genesis, `fast_download` for Anna's Archive, `eapi` for Z-Library |
+| `mirror` | The mirror or domain the route was taken against |
+| `host` | The host that actually sent the bytes, after redirects |
+
+`mirror` and `host` differ on purpose. A Library Genesis mirror hands the transfer to a content delivery network node, and a mirror can issue a working key while its node is dead — which is why failover is driven by bytes served rather than by key resolution. A field the route has no analogue for is `null` rather than invented.
+
+Provenance describes the transfer, never the document. No file content travels in it.
+
+```json
+"provenance": { "source": "libgen", "route": "get.php", "mirror": "vg", "host": "cdn3.booksdl.lc" }
+```
 
 **Example Usage:**
 
@@ -437,6 +511,8 @@ This tool accepts results from `search_books` (Z-Library) and from `search_multi
 ```json
 {
   "file_path": "./downloads/HeideggerMartin_BeingAndTime_12345678.pdf",
+  "provenance": { "source": "zlibrary", "route": "eapi", "mirror": "z-library.sk",
+                  "host": "dl.z-library.sk" },
   "processed_file_path": "./processed_rag_output/HeideggerMartin_BeingAndTime_12345678.pdf.processed.markdown",
   "metadata_file_path": "./processed_rag_output/HeideggerMartin_BeingAndTime_12345678.pdf.metadata.json",
   "footnotes_file_path": "./processed_rag_output/HeideggerMartin_BeingAndTime_12345678.pdf.processed_footnotes.markdown",
@@ -522,26 +598,67 @@ This tool accepts results from `search_books` (Z-Library) and from `search_multi
 
 ### get_download_limits
 
-**Description:** Get the user's current Z-Library download limits. Shows daily download quota, downloads used today, and remaining downloads.
+**Description:** Report each source's daily download limit. Not Z-Library only: the tool's name never named a source, and answering it with one source's numbers privileged that source in a surface that must not.
+
+Z-Library is the only source whose answer costs a network round-trip, because it is read from the authenticated account profile. Library Genesis and Anna's Archive are answered from configuration. Pass `sources` to ask about those without paying for the Z-Library call.
 
 **Parameters:**
 
-None. This tool takes no parameters.
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| sources | array | No | all sources | Which sources to report: `"annas_archive"`, `"libgen"`, `"zlibrary"`. Omit for all three. An empty array is rejected rather than treated as all three. |
 
-**Returns:** JSON object with download limit information: `daily_limit`, `downloads_today`, `remaining`.
+**Returns:** JSON object with `requested` (the sources reported, in canonical order) and `sources` (one entry per source).
+
+Each entry has the same fields as an entry in `search_multi_source`'s `routing.sources` — `available`, `routes`, `note`, `daily_limit` — plus `details` for anything a single source reports that has no counterpart elsewhere. `daily_limit.state` distinguishes *no limit exists* from *a limit exists and is not known here* from *a concrete number*; see [search_multi_source](#search_multi_source) for the table.
+
+| Source | What it reports |
+|--------|-----------------|
+| Library Genesis | `state: "none"` — known to have no daily limit, not merely unknown |
+| Z-Library | `state: "known"` with `total` / `used` / `remaining` from the account profile. Without credentials, `state: "not_applicable"` and `available: false` |
+| Anna's Archive | With `ANNAS_SECRET_KEY`, `state: "unknown"` — Anna's reports the keyed quota only in a fast-download response, so it cannot be read without spending a download. Without a key, `state: "not_applicable"` and search-only routes |
+
+A Z-Library failure — missing credentials, a refused login, a profile call that times out — degrades that one entry to `state: "unknown"` with the reason in `note`. The other sources still answer, because a credential-free Library Genesis setup is supported.
 
 **Example Usage:**
 
 ```json
 {
   "tool": "get_download_limits",
-  "arguments": {}
+  "arguments": { "sources": ["libgen"] }
+}
+```
+
+**Example Response:**
+
+```json
+{
+  "requested": ["libgen", "zlibrary"],
+  "sources": {
+    "libgen": {
+      "available": true,
+      "routes": ["search", "download"],
+      "note": "no account required; mirror li first",
+      "daily_limit": { "state": "none", "total": null, "used": null,
+                       "remaining": null, "note": "LibGen applies no daily download limit" },
+      "details": {}
+    },
+    "zlibrary": {
+      "available": true,
+      "routes": ["search", "download"],
+      "note": "credentials configured",
+      "daily_limit": { "state": "known", "total": 10, "used": 3, "remaining": 7, "note": "" },
+      "details": { "is_premium": false }
+    }
+  }
 }
 ```
 
 **Error Cases:**
-- Authentication failure
-- Network errors or rate limiting
+- `sources` names something the server does not read from
+- `sources` is an empty array
+
+A Z-Library authentication or network failure is not an error case here. It appears as that source's `daily_limit.state: "unknown"` with the reason attached.
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -618,7 +618,7 @@ Each entry has the same fields as an entry in `search_multi_source`'s `routing.s
 | Z-Library | `state: "known"` with `total` / `used` / `remaining` from the account profile. Without credentials, `state: "not_applicable"` and `available: false` |
 | Anna's Archive | With `ANNAS_SECRET_KEY`, `state: "unknown"` — Anna's reports the keyed quota only in a fast-download response, so it cannot be read without spending a download. Without a key, `state: "not_applicable"` and search-only routes |
 
-A Z-Library failure — missing credentials, a refused login, a profile call that times out — degrades that one entry to `state: "unknown"` with the reason in `note`. The other sources still answer, because a credential-free Library Genesis setup is supported.
+Missing Z-Library credentials, or a refused login while initializing the EAPI client, make that source unavailable: `available: false`, no routes, and `daily_limit.state: "not_applicable"`. A profile lookup failure *after* authentication leaves the usable routes advertised and degrades only the quota to `state: "unknown"` with the reason in `note`. The other sources still answer, because a credential-free Library Genesis setup is supported.
 
 **Example Usage:**
 
@@ -633,7 +633,7 @@ A Z-Library failure — missing credentials, a refused login, a profile call tha
 
 ```json
 {
-  "requested": ["libgen", "zlibrary"],
+  "requested": ["libgen"],
   "sources": {
     "libgen": {
       "available": true,
@@ -642,13 +642,6 @@ A Z-Library failure — missing credentials, a refused login, a profile call tha
       "daily_limit": { "state": "none", "total": null, "used": null,
                        "remaining": null, "note": "LibGen applies no daily download limit" },
       "details": {}
-    },
-    "zlibrary": {
-      "available": true,
-      "routes": ["search", "download"],
-      "note": "credentials configured",
-      "daily_limit": { "state": "known", "total": 10, "used": 3, "remaining": 7, "note": "" },
-      "details": { "is_premium": false }
     }
   }
 }
@@ -658,7 +651,7 @@ A Z-Library failure — missing credentials, a refused login, a profile call tha
 - `sources` names something the server does not read from
 - `sources` is an empty array
 
-A Z-Library authentication or network failure is not an error case here. It appears as that source's `daily_limit.state: "unknown"` with the reason attached.
+A Z-Library initialization/authentication failure is not an error case here. It appears as that source being unavailable with `daily_limit.state: "not_applicable"`; a later profile lookup failure appears as `daily_limit.state: "unknown"` while its routes remain available.
 
 ---
 

--- a/lib/python_bridge.py
+++ b/lib/python_bridge.py
@@ -29,6 +29,15 @@ from lib import enhanced_metadata
 
 # Import multi-source router
 from lib.sources.router import SourceRouter
+from lib.sources.capabilities import (
+    SOURCE_ZLIBRARY,
+    canonical_source,
+    describe_sources,
+    known_daily_limit,
+    resolve_requested_sources,
+    unknown_daily_limit,
+    zlibrary_credentials_configured,
+)
 from lib.sources.config import SourceConfig, get_source_config
 from lib.sources.errors import (
     AllSourcesFailedError,
@@ -659,8 +668,8 @@ async def get_download_history(count=10):
     return [normalize_eapi_book(b) for b in books]
 
 
-async def get_download_limits():
-    """Get user's download limits via EAPI profile.
+async def _zlibrary_daily_limit() -> tuple[dict, dict]:
+    """Read the Z-Library daily quota from the EAPI profile.
 
     /eapi/user/profile reports `downloads_limit` (the daily cap) and
     `downloads_today` (how many are spent). It has never carried
@@ -669,39 +678,118 @@ async def get_download_limits():
     tool could not answer the one question callers ask it — whether there is
     quota left to spend. Verified against a live profile response 2026-08-11.
 
-    `downloads_remaining` is derived, not reported; it is clamped at zero
-    because the server counts a download the moment it is issued and can report
+    `remaining` is derived, not reported; it is clamped at zero because the
+    server counts a download the moment it is issued and can report
     `downloads_today` above the cap.
 
     Returns:
-        dict with daily_limit, daily_remaining (both int, or "unknown" if the
-        response shape changes again), plus downloads_today and is_premium.
+        (daily_limit report, extra details) — the report is `known` only when
+        the profile carried the cap, and `unknown` with the reason otherwise.
+        A renamed field must degrade to "we do not know", never to a number
+        that happens to parse.
     """
+    global _eapi_client
+    if _eapi_client is None:
+        await initialize_eapi_client()
     eapi = await get_eapi_client()
     profile = await eapi.get_profile()
     user = profile.get("user", profile)
 
     limit = user.get("downloads_limit")
     used = user.get("downloads_today")
+    details = {"is_premium": bool(user.get("isPremium", 0))}
 
-    remaining = "unknown"
-    if isinstance(limit, int) and isinstance(used, int):
-        remaining = max(0, limit - used)
-    elif isinstance(limit, int):
-        remaining = limit
-
-    if limit is None:
+    if not isinstance(limit, int):
         logger.warning(
-            "EAPI profile has no 'downloads_limit' field; response keys: %s",
+            "EAPI profile has no integer 'downloads_limit' field; response keys: %s",
             sorted(user.keys()),
         )
+        return (
+            unknown_daily_limit(
+                "EAPI profile did not report 'downloads_limit'; the response "
+                "shape has changed"
+            ),
+            details,
+        )
 
-    return {
-        "daily_limit": limit if limit is not None else "unknown",
-        "daily_remaining": remaining,
-        "downloads_today": used if used is not None else "unknown",
-        "is_premium": bool(user.get("isPremium", 0)),
-    }
+    if isinstance(used, int):
+        return known_daily_limit(limit, used, max(0, limit - used)), details
+
+    # The cap is reported and the spend is not, so the remainder is not
+    # derivable. Reporting it as the full cap — which this function used to do
+    # — invents a number in the one surface that exists to stop that.
+    return (
+        known_daily_limit(
+            limit,
+            None,
+            None,
+            note=(
+                "EAPI profile did not report 'downloads_today'; remaining is "
+                "not derivable from the cap alone"
+            ),
+        ),
+        details,
+    )
+
+
+async def get_download_limits(sources=None):
+    """Report each source's daily download limit.
+
+    Extended from Z-Library-only to per-source by #107. The tool's name never
+    named a source, and answering it with only Z-Library's numbers privileged
+    one source in a surface that must not — invariant 4.
+
+    Cost is what splits this tool from the `routing` block on
+    `search_multi_source`: everything knowable from configuration rides along
+    with every search, and only what needs a round-trip lives here. Z-Library
+    is the sole source that costs one, so a caller asking only about LibGen
+    makes no EAPI profile call — the reason `sources` exists.
+
+    Each entry reports what it actually knows. `daily_limit.state` separates
+    *no limit exists* (LibGen) from *a limit exists but is not known here*
+    (Anna's keyed quota, which the API only discloses while spending a
+    download) from *a concrete number* (Z-Library). Collapsing those onto
+    `null` is the failure this shape prevents.
+
+    A Z-Library failure — absent credentials, a login the service refused, a
+    profile call that timed out — degrades that one entry to `unknown` with
+    the reason attached. It never fails the whole call, because a
+    credential-free LibGen setup is supported and must still get an answer.
+
+    Args:
+        sources: Source names to report, e.g. ["libgen"]. All of them when
+            omitted. Accepts 'annas' as well as 'annas_archive'.
+
+    Returns:
+        dict with `requested` (the canonical names reported, in order) and
+        `sources` (name -> entry with `available`, `routes`, `daily_limit`,
+        `note`, `details`)
+
+    Raises:
+        ValueError: If `sources` names something this server does not read
+            from, or narrows the request to nothing
+    """
+    requested = resolve_requested_sources(sources)
+    entries = describe_sources(sources=requested)
+
+    for name, entry in entries.items():
+        entry["details"] = {}
+        if name != SOURCE_ZLIBRARY:
+            continue
+        if not zlibrary_credentials_configured():
+            # describe_sources already reported this as not_applicable with
+            # the reason; spending a login attempt to confirm it would be a
+            # round-trip whose answer we already have.
+            continue
+        try:
+            entry["daily_limit"], entry["details"] = await _zlibrary_daily_limit()
+        except Exception as exc:
+            logger.warning(f"Z-Library limit lookup failed: {exc}")
+            entry["daily_limit"] = unknown_daily_limit(
+                f"Z-Library profile lookup failed: {type(exc).__name__}: {exc}"
+            )
+
+    return {"requested": requested, "sources": entries}
 
 
 # --- Core Bridge Functions ---
@@ -1097,8 +1185,55 @@ async def _download_url_to_file(
     return completed_path
 
 
-async def _fetch_from_source(book_details: dict, output_dir: str) -> str:
-    """Resolve and fetch a non-Z-Library book. Returns the raw file path."""
+def _canonical_source_name(name) -> str:
+    """Canonical source identity, or the raw name when it is not one of ours.
+
+    Reporting must never be able to fail an otherwise successful transfer, so
+    an unrecognised name is passed through rather than raised on.
+    """
+    try:
+        return canonical_source(name)
+    except ValueError:
+        return str(name)
+
+
+def _provenance(source: str, route: str = "", mirror: str = "", host: str = "") -> dict:
+    """One transfer's provenance, nested rather than flat.
+
+    Nested because `search_multi_source` spreads `**r.extra` into each book
+    dict, so a source that grew a field named `source` would collide with the
+    contract's own key and neither would be detectable (#96). The line is
+    drawn here before it is a problem rather than after.
+
+    Provenance describes the transfer, not the content — invariant 1. Values
+    the route genuinely has no analogue for are `None`, not invented.
+
+    Args:
+        source: Canonical source name that served the file
+        route: The named route taken, e.g. 'get.php' or 'eapi'
+        mirror: Mirror or domain the route was taken against
+        host: Host that actually served the bytes, after redirects
+
+    Returns:
+        dict with the same four keys whatever the source
+    """
+    return {
+        "source": source or None,
+        "route": route or None,
+        "mirror": mirror or None,
+        "host": host or None,
+    }
+
+
+async def _fetch_from_source(book_details: dict, output_dir: str) -> tuple[str, dict]:
+    """Resolve and fetch a non-Z-Library book.
+
+    Returns:
+        (raw file path, provenance) — the provenance names the mirror and the
+        host that actually served the bytes. Before #101 both were written to
+        `logger.warning` on stderr and discarded, so a caller could not tell
+        which of three LibGen mirrors had answered (found by review on #98).
+    """
     md5 = (book_details.get("md5") or "").strip().lower()
     source = (book_details.get("source") or "auto").lower()
     if not md5:
@@ -1125,18 +1260,21 @@ async def _fetch_from_source(book_details: dict, output_dir: str) -> str:
             seen_failure_ids.add(identity)
             failures.append(failure)
 
-    async def acquire() -> str:
+    async def acquire() -> tuple[str, dict]:
         nonlocal active_host
 
         candidate_stream = router.iter_download_candidates(md5, source=selection)
         try:
             async for result in candidate_stream:
-                provider = getattr(result.source, "value", result.source) or selection
-                if provider == "annas_archive":
-                    provider = "annas"
+                served_by = getattr(result.source, "value", result.source) or selection
+                # `provider` is the short name the transfer's user-agent and
+                # error attribution have always used; provenance reports the
+                # canonical identity instead, so one spelling keys `routing`,
+                # `get_download_limits` and this.
+                provider = "annas" if served_by == "annas_archive" else str(served_by)
                 active_host = (urlsplit(result.url).hostname or "").lower()
                 try:
-                    return await _download_url_to_file(
+                    path = await _download_url_to_file(
                         result.url,
                         output_dir,
                         md5,
@@ -1150,6 +1288,17 @@ async def _fetch_from_source(book_details: dict, output_dir: str) -> str:
                         record(failure)
                 except SourceError as exc:
                     record(exc)
+                else:
+                    # `active_host` over the adapter's own `host`: the adapter
+                    # observed the host that answered a probe, this observed
+                    # the one that served the bytes, and a CDN redirect can
+                    # make them differ. Provenance reports the transfer.
+                    return path, _provenance(
+                        _canonical_source_name(served_by),
+                        route=result.route,
+                        mirror=result.mirror,
+                        host=active_host or result.host,
+                    )
         except AllSourcesFailedError as exc:
             for failure in exc.failures:
                 record(failure)
@@ -1240,7 +1389,9 @@ async def download_book(
         processed_output_format: Format for RAG output ('txt' or 'markdown')
 
     Returns:
-        dict with 'file_path' and optional 'processed_file_path'
+        dict with 'file_path', 'provenance' (which source, route, mirror and
+        host actually served the bytes — see `_provenance`) and optional
+        'processed_file_path'
     """
     # A missing RAG tier is knowable before any bytes move, and finding out
     # afterwards is expensive: the file has already been fetched and published,
@@ -1281,11 +1432,17 @@ async def download_book(
     processed_file_path_str = None  # Path for RAG processed file
     process_result = None
 
+    zlibrary_served_by = ""
+
+    def _observe_zlibrary_host(host: str) -> None:
+        nonlocal zlibrary_served_by
+        zlibrary_served_by = host
+
     try:
         # Step 1: Fetch the file. Z-Library goes through the EAPI client;
         # every other source resolves a URL through the router and streams it.
         if from_source:
-            original_download_path_str = await _fetch_from_source(
+            original_download_path_str, provenance = await _fetch_from_source(
                 book_details, output_dir
             )
         else:
@@ -1293,6 +1450,15 @@ async def download_book(
                 book_id=int(book_id),
                 book_hash=book_hash,
                 output_dir=output_dir,
+                host_observer=_observe_zlibrary_host,
+            )
+            provenance = _provenance(
+                SOURCE_ZLIBRARY,
+                route="eapi",
+                # Z-Library's EAPI domain rotates, so which one answered is
+                # the same kind of fact as which LibGen mirror did.
+                mirror=getattr(eapi, "domain", ""),
+                host=zlibrary_served_by,
             )
 
         if (
@@ -1372,6 +1538,9 @@ async def download_book(
         if process_for_rag and process_result:
             result.update(process_result)
             result["file_path"] = downloaded_file_path_str
+        # Assigned after the RAG bundle merges in, so a processor that one day
+        # emits a key of this name cannot overwrite the transfer's own record.
+        result["provenance"] = provenance
         return result
 
     except Exception as e:
@@ -1560,6 +1729,45 @@ async def get_source_router() -> SourceRouter:
     return _source_router
 
 
+def _routing_report(router: SourceRouter, source: str, books: list) -> dict:
+    """What was requested, what served it, and what every source can do.
+
+    All four fields are local: the source constraints come from configuration
+    and the rest from the request and its results, so attaching this to every
+    search costs no round-trip. Facts that would cost one live in
+    `get_download_limits` instead (#96).
+
+    `fell_back` is the field this whole block exists for. `sources_used` was
+    derived from results alone, so a caller who asked for one provider and
+    received another could not tell a substitution from a direct hit — the
+    reporting half of the bug #74 fixed in routing. Comparing what served
+    against the provider the router *meant* to try first makes the
+    substitution visible without the caller diffing intent against output.
+
+    Args:
+        router: The router that ran the search, asked which provider it meant
+            to reach
+        source: The selector the caller passed, echoed verbatim as `requested`
+        books: The result dicts, whose `source` fields say who answered
+
+    Returns:
+        dict with `requested` (the selector, e.g. 'auto'), `served_by`
+        (canonical source names, sorted), `fell_back`, and `sources`
+    """
+    served_by = sorted(
+        {str(book.get("source", "")) for book in books if book.get("source")}
+    )
+    intended = router.intended_source(source)
+    return {
+        "requested": source,
+        "served_by": served_by,
+        # Nothing served means nothing was substituted. An empty result is a
+        # "no match" report, and calling it a fallback would invent an event.
+        "fell_back": bool(served_by) and intended not in served_by,
+        "sources": describe_sources(getattr(router, "config", None)),
+    }
+
+
 async def search_multi_source(
     query: str,
     source: str = "auto",
@@ -1583,7 +1791,9 @@ async def search_multi_source(
     Returns:
         dict with:
             - books: List of book dicts with md5, title, author, etc.
-            - sources_used: List of source names that provided results
+            - routing: What was asked for, what answered, and what every
+              source's locally knowable constraints are — see
+              `_routing_report`
 
     Environment:
         ANNAS_SECRET_KEY: API key for Anna's Archive fast downloads
@@ -1611,7 +1821,7 @@ async def search_multi_source(
 
     return {
         "books": books,
-        "sources_used": list(set(b["source"] for b in books)),
+        "routing": _routing_report(router, source, books),
     }
 
 
@@ -1625,6 +1835,14 @@ def _requires_eapi_client(function_name: str, args_dict: dict) -> bool:
     credential-free fallback — down with every Z-Library auth outage (#129).
     """
     if function_name in ("process_document", "search_multi_source"):
+        return False
+    if function_name == "get_download_limits":
+        # Per-source since #107: LibGen and Anna's answer from configuration,
+        # so a caller asking only about them must not pay for a Z-Library
+        # login. Z-Library's own entry logs in lazily and reports the failure
+        # as that one entry's `unknown` reason, which is why this is False
+        # even when Z-Library IS requested — an auth outage degrades one
+        # source's answer rather than the whole tool's.
         return False
     if function_name == "download_book":
         source = str((args_dict.get("book_details") or {}).get("source") or "").lower()

--- a/lib/python_bridge.py
+++ b/lib/python_bridge.py
@@ -32,6 +32,7 @@ from lib.sources.router import SourceRouter
 from lib.sources.capabilities import (
     SOURCE_ZLIBRARY,
     canonical_source,
+    daily_limit_not_applicable,
     describe_sources,
     known_daily_limit,
     resolve_requested_sources,
@@ -159,6 +160,12 @@ class InternalBookNotFoundError(Exception):
 
 class InternalParsingError(Exception):
     """Custom exception for errors during HTML parsing of book details."""
+
+    pass
+
+
+class EapiInitializationError(RuntimeError):
+    """The server could not establish an authenticated EAPI client."""
 
     pass
 
@@ -690,7 +697,10 @@ async def _zlibrary_daily_limit() -> tuple[dict, dict]:
     """
     global _eapi_client
     if _eapi_client is None:
-        await initialize_eapi_client()
+        try:
+            await initialize_eapi_client()
+        except Exception as exc:
+            raise EapiInitializationError() from exc
     eapi = await get_eapi_client()
     profile = await eapi.get_profile()
     user = profile.get("user", profile)
@@ -751,10 +761,11 @@ async def get_download_limits(sources=None):
     download) from *a concrete number* (Z-Library). Collapsing those onto
     `null` is the failure this shape prevents.
 
-    A Z-Library failure — absent credentials, a login the service refused, a
-    profile call that timed out — degrades that one entry to `unknown` with
-    the reason attached. It never fails the whole call, because a
-    credential-free LibGen setup is supported and must still get an answer.
+    Missing credentials and initialization/authentication failures report
+    Z-Library as unavailable with no routes and a `not_applicable` limit.
+    A profile call failure after authentication preserves the usable routes
+    and degrades only the quota to `unknown`. Neither failure blocks the
+    other sources, because a credential-free LibGen setup is supported.
 
     Args:
         sources: Source names to report, e.g. ["libgen"]. All of them when
@@ -783,11 +794,25 @@ async def get_download_limits(sources=None):
             continue
         try:
             entry["daily_limit"], entry["details"] = await _zlibrary_daily_limit()
-        except Exception as exc:
-            logger.warning(f"Z-Library limit lookup failed: {exc}")
-            entry["daily_limit"] = unknown_daily_limit(
-                f"Z-Library profile lookup failed: {type(exc).__name__}: {exc}"
+        except EapiInitializationError as exc:
+            cause = exc.__cause__ or exc
+            error = f"{type(cause).__name__}: {cause}"
+            logger.warning(f"Z-Library initialization failed: {error}")
+            entry["available"] = False
+            entry["routes"] = []
+            entry["daily_limit"] = daily_limit_not_applicable(
+                "Z-Library initialization failed; no authenticated route is usable"
             )
+            entry["note"] = f"Z-Library initialization failed: {error}"
+            entry["details"] = {"stage": "initialization", "error": error}
+        except Exception as exc:
+            error = f"{type(exc).__name__}: {exc}"
+            logger.warning(f"Z-Library profile lookup failed: {error}")
+            entry["daily_limit"] = unknown_daily_limit(
+                f"Z-Library profile lookup failed: {error}"
+            )
+            entry["note"] = f"Z-Library profile lookup failed: {error}"
+            entry["details"] = {"stage": "profile", "error": error}
 
     return {"requested": requested, "sources": entries}
 

--- a/lib/python_bridge.py
+++ b/lib/python_bridge.py
@@ -1818,10 +1818,11 @@ async def search_multi_source(
         }
         for r in results[:count]
     ]
+    routing_books = [{"source": r.source.value} for r in results]
 
     return {
         "books": books,
-        "routing": _routing_report(router, source, books),
+        "routing": _routing_report(router, source, routing_books),
     }
 
 

--- a/lib/sources/__init__.py
+++ b/lib/sources/__init__.py
@@ -15,6 +15,22 @@ Usage:
 
 from .annas import AnnasArchiveAdapter, QuotaExhaustedError
 from .base import SourceAdapter
+from .capabilities import (
+    KNOWN_SOURCES,
+    LIMIT_KNOWN,
+    LIMIT_NONE,
+    LIMIT_NOT_APPLICABLE,
+    LIMIT_UNKNOWN,
+    SOURCE_ANNAS,
+    SOURCE_LIBGEN,
+    SOURCE_ZLIBRARY,
+    canonical_source,
+    describe_sources,
+    known_daily_limit,
+    resolve_requested_sources,
+    unknown_daily_limit,
+    zlibrary_credentials_configured,
+)
 from .config import SourceConfig, get_source_config
 from .errors import (
     AllSourcesFailedError,
@@ -46,4 +62,18 @@ __all__ = [
     "ProviderConfigurationError",
     "ProviderResponseError",
     "AllSourcesFailedError",
+    "KNOWN_SOURCES",
+    "SOURCE_ANNAS",
+    "SOURCE_LIBGEN",
+    "SOURCE_ZLIBRARY",
+    "LIMIT_KNOWN",
+    "LIMIT_NONE",
+    "LIMIT_NOT_APPLICABLE",
+    "LIMIT_UNKNOWN",
+    "canonical_source",
+    "describe_sources",
+    "known_daily_limit",
+    "resolve_requested_sources",
+    "unknown_daily_limit",
+    "zlibrary_credentials_configured",
 ]

--- a/lib/sources/annas.py
+++ b/lib/sources/annas.py
@@ -480,6 +480,13 @@ class AnnasArchiveAdapter(SourceAdapter):
             url=download_url,
             source=SourceType.ANNAS_ARCHIVE,
             quota_info=quota_info,
+            route="fast_download",
+            # Anna's mirrors are whole domains rather than path suffixes, so
+            # the configured domain is what 'mirror' names here. The serving
+            # host is whatever the API handed back, which is a partner CDN and
+            # regularly not an Anna's domain at all.
+            mirror=self.host,
+            host=(urlsplit(download_url).hostname or "").lower(),
         )
 
     async def close(self) -> None:

--- a/lib/sources/capabilities.py
+++ b/lib/sources/capabilities.py
@@ -29,8 +29,9 @@ and paying for a round-trip that can never answer. Hence
 
 import os
 from typing import Dict, Iterable, List, Optional, Sequence
+from urllib.parse import urlsplit
 
-from .config import SourceConfig, get_source_config
+from .config import ANNAS_TRUSTED_HOSTS, SourceConfig, get_source_config
 
 # Canonical source identities. These are what appears in `routing.sources`,
 # `routing.served_by`, `provenance.source` and the `get_download_limits`
@@ -199,7 +200,8 @@ def _entry(
 
 def describe_annas(config: SourceConfig) -> Dict:
     """Anna's Archive constraints, from configuration alone."""
-    if config.has_annas_key:
+    host = (urlsplit(config.annas_base_url).hostname or "").lower()
+    if config.has_annas_key and host in ANNAS_TRUSTED_HOSTS:
         return _entry(
             available=True,
             routes=[ROUTE_SEARCH, ROUTE_DOWNLOAD],
@@ -212,6 +214,19 @@ def describe_annas(config: SourceConfig) -> Dict:
                 "cannot be read without spending one"
             ),
             note="ANNAS_SECRET_KEY configured; keyed fast download available",
+        )
+    if config.has_annas_key:
+        return _entry(
+            available=True,
+            routes=[ROUTE_SEARCH],
+            daily_limit=daily_limit_not_applicable(
+                "configured Anna's host is not trusted for keyed download"
+            ),
+            note=(
+                "ANNAS_SECRET_KEY configured, but configured host "
+                f"'{host or '<missing>'}' is not trusted for keyed download; "
+                "search only"
+            ),
         )
     return _entry(
         available=True,

--- a/lib/sources/capabilities.py
+++ b/lib/sources/capabilities.py
@@ -1,0 +1,289 @@
+"""Symmetric per-source capability and limit reporting.
+
+One vocabulary, two surfaces. The routing contract decided on #96 tells the
+caller about sources in two moments that cost different things:
+
+- inline, on every ``search_multi_source`` response (`routing.sources`) — only
+  facts decidable from configuration, never a network round-trip;
+- on demand, through ``get_download_limits`` — the same entries, with the
+  quota that costs a round-trip filled in for whichever sources were asked
+  for.
+
+Both read their entries from here so the two surfaces cannot drift into
+describing the same source two different ways.
+
+Two rules govern the shape:
+
+**Report, never rank (VISION invariant 4).** Every source gets the same key
+set. A field that exists for one source and not another is a ranking dressed
+as a schema, and the caller — not this server — chooses.
+
+**A limit is three-valued, never null.** "This source has no daily limit",
+"this source has one and we do not know it here", and "this source has one and
+it is 7 of 10" are three different facts, and collapsing them onto ``null`` is
+how a caller ends up treating LibGen's absence of a limit as an unknown quota
+and paying for a round-trip that can never answer. Hence
+:data:`LIMIT_NONE` / :data:`LIMIT_UNKNOWN` / :data:`LIMIT_KNOWN`, plus
+:data:`LIMIT_NOT_APPLICABLE` for a source with no download route to limit.
+"""
+
+import os
+from typing import Dict, Iterable, List, Optional, Sequence
+
+from .config import SourceConfig, get_source_config
+
+# Canonical source identities. These are what appears in `routing.sources`,
+# `routing.served_by`, `provenance.source` and the `get_download_limits`
+# response — one spelling everywhere, so a caller can key one dict off another.
+SOURCE_ANNAS = "annas_archive"
+SOURCE_LIBGEN = "libgen"
+SOURCE_ZLIBRARY = "zlibrary"
+
+#: Every source this server reads from, in a stable order.
+KNOWN_SOURCES: Sequence[str] = (SOURCE_ANNAS, SOURCE_LIBGEN, SOURCE_ZLIBRARY)
+
+# Accepted spellings, including the `source` selector values that
+# `search_multi_source` has always taken ("annas" rather than "annas_archive").
+_SOURCE_ALIASES: Dict[str, str] = {
+    "annas": SOURCE_ANNAS,
+    "annas_archive": SOURCE_ANNAS,
+    "annas-archive": SOURCE_ANNAS,
+    "annasarchive": SOURCE_ANNAS,
+    "libgen": SOURCE_LIBGEN,
+    "library_genesis": SOURCE_LIBGEN,
+    "zlibrary": SOURCE_ZLIBRARY,
+    "z-library": SOURCE_ZLIBRARY,
+    "zlib": SOURCE_ZLIBRARY,
+}
+
+# Route names. A route is a thing the caller can ask this server to do with a
+# source, not an internal code path.
+ROUTE_SEARCH = "search"
+ROUTE_DOWNLOAD = "download"
+
+# `daily_limit.state` values.
+LIMIT_NONE = "none"  # known to impose no daily limit
+LIMIT_KNOWN = "known"  # concrete numbers, measured this call
+LIMIT_UNKNOWN = "unknown"  # a limit exists but is not known here
+LIMIT_NOT_APPLICABLE = "not_applicable"  # no download route to limit
+
+
+def canonical_source(name: str) -> str:
+    """Map any accepted spelling of a source onto its canonical identity.
+
+    Args:
+        name: Source name or selector value, in any accepted spelling
+
+    Returns:
+        One of :data:`KNOWN_SOURCES`
+
+    Raises:
+        ValueError: If the name is not a source this server reads from
+    """
+    key = str(name or "").strip().lower()
+    try:
+        return _SOURCE_ALIASES[key]
+    except KeyError:
+        raise ValueError(
+            f"Unknown source '{name}'. Known sources: {', '.join(KNOWN_SOURCES)}."
+        ) from None
+
+
+def resolve_requested_sources(sources: Optional[Iterable[str]]) -> List[str]:
+    """Normalize a caller's source selection, preserving :data:`KNOWN_SOURCES` order.
+
+    ``None`` — the caller did not narrow the request — means every source. An
+    explicit empty list is a caller asking about nothing and is rejected
+    rather than silently widened to everything: a request that narrows to
+    nothing is a mistake, and answering it with all three would spend a
+    round-trip the caller was trying to avoid.
+
+    Args:
+        sources: Source names in any accepted spelling, or None for all
+
+    Returns:
+        Canonical source names, deduplicated, in canonical order
+
+    Raises:
+        ValueError: If a name is unknown, or the selection is explicitly empty
+    """
+    if sources is None:
+        return list(KNOWN_SOURCES)
+    if isinstance(sources, str):
+        sources = [sources]
+
+    selected = {canonical_source(name) for name in sources}
+    if not selected:
+        raise ValueError(
+            "'sources' must name at least one source, or be omitted to report "
+            f"all of them. Known sources: {', '.join(KNOWN_SOURCES)}."
+        )
+    return [name for name in KNOWN_SOURCES if name in selected]
+
+
+def _daily_limit(
+    state: str,
+    *,
+    total: Optional[int] = None,
+    used: Optional[int] = None,
+    remaining: Optional[int] = None,
+    note: str = "",
+) -> Dict:
+    """One daily-limit report. Same keys whatever the state, so a caller can
+    read `state` first and the numbers second without probing for keys."""
+    return {
+        "state": state,
+        "total": total,
+        "used": used,
+        "remaining": remaining,
+        "note": note,
+    }
+
+
+def no_daily_limit(note: str = "") -> Dict:
+    """This source is known to impose no daily download limit."""
+    return _daily_limit(LIMIT_NONE, note=note)
+
+
+def unknown_daily_limit(note: str = "") -> Dict:
+    """A daily limit exists, but its value is not known at this point.
+
+    The note says what would answer it — a different tool, a configuration
+    change, or a request that has not happened yet.
+    """
+    return _daily_limit(LIMIT_UNKNOWN, note=note)
+
+
+def known_daily_limit(
+    total: Optional[int], used: Optional[int], remaining: Optional[int], note: str = ""
+) -> Dict:
+    """Concrete numbers, measured on this call."""
+    return _daily_limit(
+        LIMIT_KNOWN, total=total, used=used, remaining=remaining, note=note
+    )
+
+
+def daily_limit_not_applicable(note: str = "") -> Dict:
+    """No download route is available, so there is no quota to report."""
+    return _daily_limit(LIMIT_NOT_APPLICABLE, note=note)
+
+
+def zlibrary_credentials_configured() -> bool:
+    """Whether Z-Library credentials are present in the environment.
+
+    A local check by design: `routing` must cost no network, and an absent
+    credential is decidable without one. Whether the credentials are *valid*
+    is not knowable here and is not claimed.
+    """
+    return bool(
+        os.environ.get("ZLIBRARY_EMAIL") and os.environ.get("ZLIBRARY_PASSWORD")
+    )
+
+
+def _entry(
+    available: bool, routes: Sequence[str], daily_limit: Dict, note: str
+) -> Dict:
+    """One source entry. Identical key set for every source — see module docstring.
+
+    ``available`` means "at least one route is usable right now", not "this
+    source can do everything". A source that can be searched but not
+    downloaded from is available, and its `routes` list says which half.
+    """
+    return {
+        "available": available,
+        "routes": list(routes),
+        "daily_limit": daily_limit,
+        "note": note,
+    }
+
+
+def describe_annas(config: SourceConfig) -> Dict:
+    """Anna's Archive constraints, from configuration alone."""
+    if config.has_annas_key:
+        return _entry(
+            available=True,
+            routes=[ROUTE_SEARCH, ROUTE_DOWNLOAD],
+            # Anna's reports the keyed quota in the fast-download response
+            # itself, so there is no way to learn it without spending a
+            # download. Reporting it as unknown-with-a-reason is the honest
+            # answer; inventing a number or a round-trip is not.
+            daily_limit=unknown_daily_limit(
+                "Anna's reports the keyed quota with each fast download; it "
+                "cannot be read without spending one"
+            ),
+            note="ANNAS_SECRET_KEY configured; keyed fast download available",
+        )
+    return _entry(
+        available=True,
+        routes=[ROUTE_SEARCH],
+        daily_limit=daily_limit_not_applicable(
+            "no download route without ANNAS_SECRET_KEY"
+        ),
+        note="no ANNAS_SECRET_KEY; search only, download unavailable",
+    )
+
+
+def describe_libgen(config: SourceConfig) -> Dict:
+    """LibGen constraints, from configuration alone."""
+    return _entry(
+        available=True,
+        routes=[ROUTE_SEARCH, ROUTE_DOWNLOAD],
+        daily_limit=no_daily_limit("LibGen applies no daily download limit"),
+        note=f"no account required; mirror {config.libgen_mirror} first",
+    )
+
+
+def describe_zlibrary(_config: SourceConfig) -> Dict:
+    """Z-Library constraints, from configuration alone.
+
+    The quota is deliberately `unknown` here rather than fetched: reading it
+    costs an authenticated EAPI profile call, and making every LibGen-only
+    search pay for one buys a symmetry nobody benefits from (#96).
+    """
+    if not zlibrary_credentials_configured():
+        return _entry(
+            available=False,
+            routes=[],
+            daily_limit=daily_limit_not_applicable(
+                "ZLIBRARY_EMAIL / ZLIBRARY_PASSWORD not configured"
+            ),
+            note="no Z-Library credentials configured",
+        )
+    return _entry(
+        available=True,
+        routes=[ROUTE_SEARCH, ROUTE_DOWNLOAD],
+        daily_limit=unknown_daily_limit(
+            "costs an EAPI profile call; ask get_download_limits"
+        ),
+        note="credentials configured",
+    )
+
+
+_DESCRIBERS = {
+    SOURCE_ANNAS: describe_annas,
+    SOURCE_LIBGEN: describe_libgen,
+    SOURCE_ZLIBRARY: describe_zlibrary,
+}
+
+
+def describe_sources(
+    config: Optional[SourceConfig] = None,
+    sources: Optional[Iterable[str]] = None,
+) -> Dict[str, Dict]:
+    """Locally knowable constraints for each source, keyed by canonical name.
+
+    No network call happens here, and none may be added: this is what rides
+    along with every search response.
+
+    Args:
+        config: Source configuration. Loaded from the environment if omitted.
+        sources: Which sources to describe. All of them if omitted.
+
+    Returns:
+        Mapping of canonical source name to an entry with the identical key
+        set described in the module docstring
+    """
+    resolved = config or get_source_config()
+    return {
+        name: _DESCRIBERS[name](resolved) for name in resolve_requested_sources(sources)
+    }

--- a/lib/sources/libgen.py
+++ b/lib/sources/libgen.py
@@ -700,6 +700,12 @@ class LibgenAdapter(SourceAdapter):
                     url=url,
                     source=SourceType.LIBGEN,
                     quota_info=None,  # LibGen has no quota
+                    route="get.php",
+                    mirror=mirror,
+                    # On the success path `_serves_bytes` returns the host that
+                    # actually answered the probe, which is the CDN node rather
+                    # than the mirror — the distinction failover exists for.
+                    host=detail,
                 )
 
         if failures:

--- a/lib/sources/models.py
+++ b/lib/sources/models.py
@@ -62,10 +62,31 @@ class QuotaInfo:
 class DownloadResult:
     """Result of a download URL request.
 
-    Contains the resolved download URL and optional quota information
-    (for Anna's Archive which has daily limits).
+    Contains the resolved download URL, optional quota information (for
+    Anna's Archive which has daily limits), and the provenance of the route
+    that resolved it.
+
+    `route`, `mirror` and `host` exist so acquisition can *return* what served
+    the file instead of only logging it. Before #101 they did not, so the
+    adapters wrote provenance to `logger.warning` on stderr and the caller
+    never saw which mirror or CDN node had answered (found by review on #98).
+    They default to empty so an adapter that genuinely has no mirror concept
+    is not forced to invent one.
+
+    Attributes:
+        url: Resolved download URL
+        source: Which source resolved it
+        quota_info: Remaining daily downloads, where the source reports them
+        route: The named route that resolved the URL, e.g. 'get.php'
+        mirror: The mirror or domain the route was taken against, e.g. 'vg'
+        host: The host expected to serve the bytes, where resolution observed
+            it — a mirror can hand out a valid key while its CDN node is dead,
+            so this is not always the mirror
     """
 
     url: str
     source: SourceType
     quota_info: Optional[QuotaInfo] = None
+    route: str = ""
+    mirror: str = ""
+    host: str = ""

--- a/lib/sources/router.py
+++ b/lib/sources/router.py
@@ -14,6 +14,7 @@ import inspect
 from typing import AsyncIterator, List, Literal, Optional
 
 from .annas import AnnasArchiveAdapter, QuotaExhaustedError
+from .capabilities import canonical_source
 from .config import SourceConfig, get_source_config
 from .errors import AllSourcesFailedError, SourceError
 from .libgen import LibgenAdapter
@@ -100,6 +101,24 @@ class SourceRouter:
         if source == "auto":
             return "annas" if self.config.has_annas_key else "libgen"
         return source
+
+    def intended_source(self, source: SourceSelection = "auto") -> str:
+        """Canonical identity of the provider this request is expected to reach.
+
+        The reporting half of routing needs this, and cannot derive it from
+        the results: a caller who asks for `auto` and receives LibGen has no
+        way to tell a first-choice hit from a substitution unless the server
+        says which provider it meant to try first. That is precisely the gap
+        `sources_used` left open — it was computed from results, so a fallback
+        was indistinguishable from a direct hit (#96).
+
+        Args:
+            source: Requested source ('auto', 'annas', or 'libgen')
+
+        Returns:
+            A canonical source name from `lib.sources.capabilities`
+        """
+        return canonical_source(self._determine_source(source))
 
     def _search_candidates(self, source: SourceSelection) -> List[SourceSelection]:
         """Ordered providers to try for a search.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "zlibrary-mcp": "dist/index.js"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && npm run test:types",
+    "test:types": "tsc --project tsconfig.types.json",
     "postbuild": "node scripts/validate-python-bridge.js",
     "validate": "node scripts/validate-python-bridge.js",
     "audit:release": "node scripts/release-audit.mjs",

--- a/scripts/check_optional_imports.py
+++ b/scripts/check_optional_imports.py
@@ -112,10 +112,15 @@ async def _run_core_smoke(repo_root: Path) -> None:
     from lib.rag.orchestrator_pdf import process_pdf_structured
 
     class OfflineRouter:
+        config = None
+
         async def search(self, query, source="auto", **kwargs):
             if query != "offline boundary probe":
                 raise AssertionError(f"unexpected smoke query: {query!r}")
             return []
+
+        def intended_source(self, source="auto"):
+            return "libgen"
 
         async def close(self):
             return None
@@ -142,8 +147,15 @@ async def _run_core_smoke(repo_root: Path) -> None:
 
     envelope = json.loads(stdout.getvalue())
     result = json.loads(envelope["content"][0]["text"])
-    if result != {"books": [], "sources_used": []}:
+    routing = result.get("routing", {})
+    if result.get("books") != [] or routing.get("served_by") != []:
         raise AssertionError(f"unexpected bridge search result: {result!r}")
+    # The routing contract (#101) rides along with every search and is built
+    # from configuration alone, so it must survive a core-only install.
+    if routing.get("fell_back") is not False or "libgen" not in routing.get(
+        "sources", {}
+    ):
+        raise AssertionError(f"missing routing report in bridge result: {result!r}")
 
     original_pymupdf = facade.PYMUPDF_AVAILABLE
     original_ebooklib = facade.EBOOKLIB_AVAILABLE

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,17 @@ const GetDownloadHistoryParamsSchema = z.object({
   count: z.number().int().optional().default(10).describe('Number of results to return'),
 });
 
-const GetDownloadLimitsParamsSchema = z.object({});
+const SourceNameSchema = z.enum(['annas_archive', 'libgen', 'zlibrary']);
+
+const GetDownloadLimitsParamsSchema = z.object({
+  sources: z
+    .array(SourceNameSchema)
+    .nonempty()
+    .optional()
+    .describe(
+      'Which sources to report. All of them when omitted. Naming only sources whose limits are known from configuration (libgen, annas_archive) avoids the Z-Library profile round-trip entirely.',
+    ),
+});
 
 const GetRecentBooksParamsSchema = z.object({
   count: z.number().int().optional().default(10).describe('Number of books to return'),
@@ -374,9 +384,12 @@ const handlers: HandlerMap = {
     }
   },
 
-  getDownloadLimits: async (_args: unknown, options: HandlerOptions = {}) => {
+  getDownloadLimits: async (
+    args: z.infer<typeof GetDownloadLimitsParamsSchema>,
+    options: HandlerOptions = {},
+  ) => {
     try {
-      return await zlibraryApi.getDownloadLimits(options);
+      return await zlibraryApi.getDownloadLimits({ sources: args?.sources }, options);
     } catch (error: any) {
       return { error: { message: error.message || 'Failed to get download limits' } };
     }
@@ -565,7 +578,7 @@ const toolRegistry: Record<string, ToolRegistryEntry> = {
     handler: handlers.getDownloadHistory,
   },
   get_download_limits: {
-    description: 'Get download limits',
+    description: 'Get per-source download limits',
     schema: GetDownloadLimitsParamsSchema,
     handler: handlers.getDownloadLimits,
   },
@@ -673,8 +686,10 @@ function validateCredentials(): void {
 
     logger.warn(
       `Missing environment variable(s): ${missing.join(', ')} — ` +
-        `Z-Library tools (search_books, full_text_search, get_download_limits, ` +
-        `download history) will fail when called. LibGen is unaffected: use ` +
+        `Z-Library tools (search_books, full_text_search, download history) ` +
+        `will fail when called, and get_download_limits will report ` +
+        `Z-Library as unavailable while still answering for the other ` +
+        `sources. LibGen is unaffected: use ` +
         `search_multi_source with source="libgen" and pass results to ` +
         `download_book_to_file. To enable Z-Library, set "env": ` +
         `{"ZLIBRARY_EMAIL": "...", "ZLIBRARY_PASSWORD": "..."} in your MCP ` +
@@ -764,12 +779,12 @@ async function start(
     // 4. get_download_limits
     server.tool(
       'get_download_limits',
-      "Get the user's current Z-Library download limits. Shows daily download quota, downloads used today, and remaining downloads.",
+      "Report each source's daily download limit. Every entry says which of the three it is reporting — no limit exists, a limit exists but is not known here, or a concrete number. Z-Library is the only source whose answer costs a round-trip, so pass `sources` to ask about the others without paying for it.",
       GetDownloadLimitsParamsSchema.shape,
       ann('get_download_limits'),
-      async (_args, extra) =>
+      async (args, extra) =>
         wrapResult(
-          await handlers.getDownloadLimits(_args, { signal: extra?.signal }),
+          await handlers.getDownloadLimits(args as any, { signal: extra?.signal }),
           'get_download_limits',
         ),
     );
@@ -889,7 +904,7 @@ async function start(
     // 13. search_multi_source
     server.tool(
       'search_multi_source',
-      "Search for books across Anna's Archive and LibGen. Alternative to Z-Library EAPI. Returns books with md5, title, author, year, extension, size, source, download_url. Use source=auto to prefer Anna's Archive with LibGen fallback, or force a specific source.",
+      "Search for books across Anna's Archive and LibGen. Alternative to Z-Library EAPI. Returns books with md5, title, author, year, extension, size, source, download_url, plus a `routing` block naming what was requested, what served it, whether a fallback happened, and each source's current routes and daily limit. Use source=auto to prefer Anna's Archive with LibGen fallback, or force a specific source.",
       SearchMultiSourceParamsSchema.shape,
       ann('search_multi_source'),
       async (args, extra) =>

--- a/src/lib/zlibrary-api.ts
+++ b/src/lib/zlibrary-api.ts
@@ -250,6 +250,10 @@ interface GetDownloadHistoryArgs {
     count?: number;
 }
 
+interface GetDownloadLimitsArgs {
+    sources?: string[];
+}
+
 interface DownloadBookToFileArgs {
     // id: string; // Replaced by bookDetails
     // format?: string | null; // Replaced by bookDetails
@@ -434,15 +438,27 @@ export async function getDownloadHistory({ count = 10 }: GetDownloadHistoryArgs,
  * @param args - Optional canonical source names to report
  * @param options - Timeout and abort signal
  */
+export function getDownloadLimits(options?: CallOptions): Promise<any>;
+export function getDownloadLimits(
+  args: GetDownloadLimitsArgs,
+  options?: CallOptions,
+): Promise<any>;
 export async function getDownloadLimits(
-  args: { sources?: string[] } = {},
-  options: CallOptions = {},
+  argsOrOptions: GetDownloadLimitsArgs | CallOptions = {},
+  options?: CallOptions,
 ): Promise<any> {
-  // Omit the key entirely when unset: the bridge reads `sources: null` as
-  // "every source", and sending an explicit null would be a second spelling
-  // of the default for no gain.
-  const pythonArgs = args?.sources?.length ? { sources: args.sources } : {};
-  return await callPythonFunction('get_download_limits', pythonArgs, options);
+  const hasSources = Object.prototype.hasOwnProperty.call(argsOrOptions, 'sources');
+  const args = hasSources ? argsOrOptions as GetDownloadLimitsArgs : {};
+  const callOptions = options ?? (hasSources
+    ? {
+        timeoutMs: (argsOrOptions as CallOptions).timeoutMs,
+        signal: (argsOrOptions as CallOptions).signal,
+      }
+    : argsOrOptions as CallOptions);
+  // Omit the key only when it is unset. An explicit empty list has different
+  // semantics: the bridge rejects it rather than widening it to every source.
+  const pythonArgs = args.sources === undefined ? {} : { sources: args.sources };
+  return await callPythonFunction('get_download_limits', pythonArgs, callOptions);
 }
 
 

--- a/src/lib/zlibrary-api.ts
+++ b/src/lib/zlibrary-api.ts
@@ -423,11 +423,26 @@ export async function getDownloadHistory({ count = 10 }: GetDownloadHistoryArgs,
 }
 
 /**
- * Get user's download limits
+ * Report each source's daily download limit.
+ *
+ * `sources` narrows the report. It is not a filter applied after the fact:
+ * Z-Library is the only source whose limit costs an authenticated profile
+ * call, so a request that does not name it makes no such call at all. That
+ * asymmetry of cost is why this half of the routing contract is pull-only
+ * rather than riding along with every search (#107).
+ *
+ * @param args - Optional canonical source names to report
+ * @param options - Timeout and abort signal
  */
-export async function getDownloadLimits(options: CallOptions = {}): Promise<any> {
-  // Pass arguments as an object matching Python function signature
-  return await callPythonFunction('get_download_limits', {}, options);
+export async function getDownloadLimits(
+  args: { sources?: string[] } = {},
+  options: CallOptions = {},
+): Promise<any> {
+  // Omit the key entirely when unset: the bridge reads `sources: null` as
+  // "every source", and sending an explicit null would be a second spelling
+  // of the default for no gain.
+  const pythonArgs = args?.sources?.length ? { sources: args.sources } : {};
+  return await callPythonFunction('get_download_limits', pythonArgs, options);
 }
 
 

--- a/src/lib/zlibrary-api.ts
+++ b/src/lib/zlibrary-api.ts
@@ -285,8 +285,16 @@ interface ProcessedDocumentBundle {
   output_files?: Record<string, string>;
 }
 
-interface DownloadBookResult extends ProcessedDocumentBundle {
+export interface DownloadProvenance {
+  source: string | null;
+  route: string | null;
+  mirror: string | null;
+  host: string | null;
+}
+
+export interface DownloadBookResult extends ProcessedDocumentBundle {
   file_path: string;
+  provenance: DownloadProvenance;
   processing_error?: string;
 }
 
@@ -316,6 +324,27 @@ function validateNullablePathField(result: Record<string, any>, fieldName: strin
   const value = result[fieldName];
   if (value !== null && typeof value !== 'string') {
     throw new Error(`Invalid response from Python bridge: ${fieldName} must be a string or null.`);
+  }
+}
+
+function validateDownloadProvenance(result: Record<string, any>): void {
+  if (!('provenance' in result)) {
+    throw new Error('Invalid response from Python bridge: Missing provenance.');
+  }
+  const provenance = result.provenance;
+  if (!provenance || typeof provenance !== 'object' || Array.isArray(provenance)) {
+    throw new Error('Invalid response from Python bridge: provenance must be an object.');
+  }
+  for (const field of ['source', 'route', 'mirror', 'host']) {
+    if (!(field in provenance)) {
+      throw new Error(`Invalid response from Python bridge: Missing provenance.${field}.`);
+    }
+    const value = provenance[field];
+    if (value !== null && typeof value !== 'string') {
+      throw new Error(
+        `Invalid response from Python bridge: provenance.${field} must be a string or null.`,
+      );
+    }
   }
 }
 
@@ -522,8 +551,10 @@ export async function downloadBookToFile({
     }
 
     if (typeof result.file_path !== 'string') {
-        throw new Error("Invalid response from Python bridge: file_path must be a string.");
+      throw new Error("Invalid response from Python bridge: file_path must be a string.");
     }
+
+    validateDownloadProvenance(result);
 
     if (process_for_rag && !('processed_file_path' in result)) {
         throw new Error("Invalid response from Python bridge: Processing requested but processed_file_path key is missing.");

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "declaration": false,
+    "declarationMap": false,
+    "incremental": false
+  },
+  "include": ["src/**/*.ts", "__tests__/types/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/zlibrary/src/zlibrary/eapi.py
+++ b/zlibrary/src/zlibrary/eapi.py
@@ -13,8 +13,8 @@ import aiofiles
 import os
 import tempfile
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Union
-from urllib.parse import unquote
+from typing import Any, Callable, Dict, List, Optional, Sequence, Union
+from urllib.parse import unquote, urlsplit
 
 from .logger import logger
 
@@ -398,6 +398,7 @@ class EAPIClient:
         book_hash: str,
         output_dir: str,
         filename: Optional[str] = None,
+        host_observer: Optional[Callable[[str], None]] = None,
     ) -> str:
         """Download a book file using EAPI download link.
 
@@ -406,6 +407,12 @@ class EAPIClient:
             book_hash: Book hash for URL construction
             output_dir: Directory to save the file
             filename: Optional filename; derived from response headers or URL if omitted
+            host_observer: Called once with the host that actually served the
+                bytes, after redirects. Z-Library hands downloads to a
+                changing set of delivery hosts, so the domain the client is
+                configured for is not evidence of which one answered — and
+                reporting the transfer's real host is what `provenance` on the
+                acquisition response exists to do (#101).
 
         Returns:
             Absolute path to the downloaded file
@@ -445,6 +452,14 @@ class EAPIClient:
                 timeout=httpx.Timeout(60.0, connect=10.0),
             ) as dl_client:
                 async with dl_client.stream("GET", download_url) as response:
+                    if host_observer is not None:
+                        response_url = getattr(response, "url", None)
+                        served_by = (
+                            urlsplit(str(response_url)).hostname
+                            if response_url is not None
+                            else None
+                        ) or (urlsplit(download_url).hostname or "")
+                        host_observer(served_by.lower())
                     response.raise_for_status()
 
                     # Determine filename


### PR DESCRIPTION
Implements the source/route reporting contract decided on #96. Both halves ride
in one PR because they are one contract: #101 is the inline half, #107 the
pull-only half, and they share a vocabulary that would be meaningless split
across two merges.

Closes #101
Closes #107

Both issues name #106 as a blocker. #106 merged; this is written on top of it.

## The contract

Three surfaces, one vocabulary — `lib/sources/capabilities.py`. Two surfaces
describing the same source cannot drift into describing it two different ways,
because they read the same builders.

**1. `search_multi_source` gains `routing`.**

```json
"routing": {
  "requested": "annas",
  "served_by": ["libgen"],
  "fell_back": true,
  "sources": {
    "annas_archive": { "available": true, "routes": ["search"],
                       "note": "no ANNAS_SECRET_KEY; search only, download unavailable",
                       "daily_limit": { "state": "not_applicable", ... } },
    "libgen":        { "available": true, "routes": ["search", "download"],
                       "note": "no account required; mirror li first",
                       "daily_limit": { "state": "none", ... } },
    "zlibrary":      { "available": true, "routes": ["search", "download"],
                       "note": "credentials configured",
                       "daily_limit": { "state": "unknown", ... } }
  }
}
```

Every field is decidable from configuration, so attaching it to every search
costs no round-trip. `fell_back` is the field the block exists for: `sources_used`
was computed from the results, so an `annas`-requested search that fell back
reported `["libgen"]` with no trace of the substitution — the reporting half of
the bug #74 fixed in routing. It is computed against the provider the router
*meant* to reach first (`SourceRouter.intended_source`), which is the one thing
the results cannot tell you.

`sources_used` is removed, per #96 and ADR-011 §5.

**2. Acquisition returns nested `provenance`.**

```json
"provenance": { "source": "libgen", "route": "get.php", "mirror": "vg", "host": "cdn3.booksdl.lc" }
```

`DownloadResult` gains `route` / `mirror` / `host`; before this it carried
`url`, `source`, `quota_info` only, so provenance went to `logger.warning` on
stderr and never reached the caller (found by review on #98). `mirror` and
`host` stay separate because a mirror can issue a working key while its CDN
node is dead — the distinction failover is driven by. `host` is taken from the
transfer's own observation rather than the resolution probe's, so a redirect is
reported honestly.

Nested, not flat: `search_multi_source` spreads `**r.extra` into each book
dict, so a source growing a field named `source` would collide silently.

**3. `get_download_limits` reports per source**, with an optional `sources`
parameter. Z-Library is the only source whose answer costs a round-trip, so a
LibGen-only question makes no EAPI profile call — a test asserts it, since that
is the decision's whole point. Its Z-Library entry logs in lazily, so an auth
outage degrades that one entry to `unknown` with the reason rather than failing
the tool; a credential-free LibGen setup still gets an answer.

## Three states, never null

`daily_limit.state` keeps apart what a bare `null` collapses:

| state | meaning |
|---|---|
| `none` | known to impose no daily limit (LibGen) |
| `known` | the source reported its cap; omitted values stay `null` with the reason, never a derived guess |
| `unknown` | a limit exists and is not knowable here; `note` says what would answer it |
| `not_applicable` | no download route right now, so no quota |

A cap reported without a spend now yields `remaining: null` with the reason.
The old code returned the full cap, which was a fabricated number in the one
surface built to prevent one.

## Invariants

- **Report, never rank.** Every source carries an identical key set, asserted
  by test rather than by convention.
- **Tool count stays 13.** Both surfaces extend existing tools; README and
  `docs/api.md` updated in the same commit.
- **stdout stays the protocol channel.** No `console.log` added;
  `stdio-purity.test.js` passes.
- **Files, not payloads.** Provenance describes the transfer, never the
  document.

## Deviations from the issues, and why

- **#96's example writes `"daily_limit": null` for LibGen and the string
  `"see get_download_limits"` for Z-Library.** Both are implemented as the
  structured `daily_limit` object above instead. The literal shape collapses
  *no limit exists* onto `null` and encodes a second fact as English prose in a
  value slot, which #107's own acceptance criteria forbid. `requested`,
  `served_by`, `fell_back` and the per-source entry are as specified.
- **#107 says Anna's reports "the keyed quota when `ANNAS_SECRET_KEY` is
  configured".** Anna's discloses that quota only inside a `fast_download`
  response, so reading it costs a download. There is no standalone quota
  endpoint I could verify. Keyed Anna's therefore reports `state: "unknown"`
  with that reason in `note` rather than spending a download or inventing a
  number. If a quota endpoint exists, this becomes a `known` entry with no
  change to the shape.

## Verification

- Python: 1387 passed, 185 deselected, 7 xfailed (`pytest -m "not slow and not
  integration and not performance"`).
- Node: 285 passed across 14 suites; `tsc --noEmit`, `eslint src/`,
  `prettier --check src/` clean.
- `scripts/validate-readme-tools.sh` and `scripts/check_optional_imports.py`
  pass.

New tests: `__tests__/python/test_routing_contract.py` and
`test_source_capabilities.py`. The one that matters is
`test_a_fallback_to_another_source_is_visible_in_the_response` — asking for
Anna's and silently receiving LibGen is the failure this whole contract exists
to prevent, and it fails without the change.
