### PR TITLE
fix: reuse EAPI sessions and select accounts by download quota

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,11 +390,38 @@ The server requires Z-Library credentials, set as environment variables:
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `ZLIBRARY_EMAIL` | Yes | Z-Library account email |
-| `ZLIBRARY_PASSWORD` | Yes | Z-Library account password |
+| `ZLIBRARY_EMAIL` | Unless using an account pool | Z-Library account email |
+| `ZLIBRARY_PASSWORD` | Unless using an account pool | Z-Library account password |
+| `ZLIBRARY_ACCOUNT_CREDENTIALS` | No | Secret JSON array of email/password objects; overrides the single-account pair |
+| `ZLIBRARY_SESSION_DIR` | No | Private session directory; defaults to `~/.cache/zlibrary-mcp/sessions` |
 | `ZLIBRARY_MIRROR` | No | Custom Z-Library mirror URL |
 
-The server validates credentials at startup and emits a clear error if they are missing.
+Z-Library operations validate credentials when called; credential-free sources remain available.
+
+### Sessions and automatic account selection
+
+Successful logins are reused across Python bridge invocations. Session cookies are
+stored outside downloads, with directory mode 0700 and file mode 0600 on POSIX.
+Keep this directory on persistent local storage if the MCP runs in a container.
+A profile request validates a cached session; only an explicit login rejection
+causes reauthentication. Network failures do not cause repeated logins. When the
+upstream rejects excessive logins, a five-minute local cooldown prevents immediate
+retries; the upstream may require longer before it accepts another login.
+
+For multiple accounts, set `ZLIBRARY_ACCOUNT_CREDENTIALS` to a JSON array of objects
+with `email` and `password` fields, using your MCP client's secret/environment
+configuration. Never put real credentials in repository files or tool arguments.
+The array replaces the legacy single-account pair when present.
+
+Search and history use the first account. `get_download_limits` reports the pool
+total and per-account quotas. Before a pooled Z-Library download, the
+bridge reads each account's actual daily limit and usage and selects the first
+account with remaining quota. Selection and download are serialized across bridge
+processes sharing the session directory. The result's `account_index` is the
+one-based position of the selected account; email addresses are not returned.
+Unknown quota, login restrictions, and download errors stop the operation without
+rotating accounts or replaying a download. When all quotas are exhausted, the error
+says so. Activity outside this MCP can still consume quota concurrently.
 
 ### Logging
 

--- a/__tests__/python/test_eapi_accounts.py
+++ b/__tests__/python/test_eapi_accounts.py
@@ -1,0 +1,174 @@
+"""Automatic choice uses observed quotas, never a guessed daily allowance."""
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from lib import eapi_accounts
+
+
+@pytest.fixture
+def accounts(monkeypatch, tmp_path):
+    monkeypatch.setenv("ZLIBRARY_SESSION_DIR", str(tmp_path / "sessions"))
+    monkeypatch.setenv(
+        "ZLIBRARY_ACCOUNT_CREDENTIALS",
+        json.dumps(
+            [
+                {"email": "one@example.test", "password": "test-password-one"},
+                {"email": "two@example.test", "password": "test-password-two"},
+            ]
+        ),
+    )
+    return eapi_accounts.configured_accounts()
+
+
+def client(limit, used):
+    value = AsyncMock()
+    value.get_profile.return_value = {
+        "success": 1,
+        "user": {"downloads_limit": limit, "downloads_today": used},
+    }
+    return value
+
+
+async def test_exhausted_first_account_selects_second(accounts):
+    first, second = client(10, 10), client(10, 3)
+    initialize = AsyncMock(side_effect=[first, second])
+    async with eapi_accounts.download_client(accounts, initialize) as (index, selected):
+        assert index == 2
+        assert selected is second
+    first.close.assert_awaited_once()
+    assert initialize.await_args_list[1].args == (accounts[1],)
+
+
+async def test_first_account_with_quota_is_reused_without_logging_into_others(accounts):
+    first = client(20, 12)
+    initialize = AsyncMock(return_value=first)
+    async with eapi_accounts.download_client(accounts, initialize) as (index, selected):
+        assert index == 1
+        assert selected is first
+    initialize.assert_awaited_once_with(accounts[0])
+
+
+async def test_all_accounts_exhausted_is_explicit(accounts):
+    initialize = AsyncMock(side_effect=[client(10, 10), client(10, 11)])
+    with pytest.raises(RuntimeError, match="All configured.*quota"):
+        async with eapi_accounts.download_client(accounts, initialize):
+            pytest.fail("must not dispatch a download")
+
+
+async def test_unknown_quota_does_not_guess_or_rotate(accounts):
+    initialize = AsyncMock(return_value=client(None, 0))
+    with pytest.raises(RuntimeError, match="quota.*unknown"):
+        async with eapi_accounts.download_client(accounts, initialize):
+            pytest.fail("must not dispatch")
+    initialize.assert_awaited_once()
+
+
+async def test_login_error_does_not_rotate(accounts):
+    initialize = AsyncMock(side_effect=RuntimeError("Too many logins"))
+    with pytest.raises(RuntimeError, match="Too many logins"):
+        async with eapi_accounts.download_client(accounts, initialize):
+            pytest.fail("must not dispatch")
+    initialize.assert_awaited_once()
+
+
+async def test_uncertain_download_is_not_replayed_on_another_account(accounts):
+    initialize = AsyncMock(return_value=client(10, 0))
+    with pytest.raises(TimeoutError):
+        async with eapi_accounts.download_client(accounts, initialize):
+            raise TimeoutError("download outcome unknown")
+    initialize.assert_awaited_once()
+
+
+def test_legacy_credentials_remain_supported(monkeypatch):
+    monkeypatch.delenv("ZLIBRARY_ACCOUNT_CREDENTIALS", raising=False)
+    monkeypatch.setenv("ZLIBRARY_EMAIL", "legacy@example.test")
+    monkeypatch.setenv("ZLIBRARY_PASSWORD", "test-password")
+    result = eapi_accounts.configured_accounts()
+    assert len(result) == 1
+    assert result[0].email == "legacy@example.test"
+    assert result[0].password == "test-password"
+    assert "test-password" not in repr(result)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["not-json", "{}", "[]", '[{"email":"one"}]', '[{"email":"one","password":null}]'],
+)
+def test_invalid_pool_is_reported_without_leaking_values(monkeypatch, raw):
+    monkeypatch.setenv("ZLIBRARY_ACCOUNT_CREDENTIALS", raw)
+    with pytest.raises(ValueError, match="ZLIBRARY_ACCOUNT_CREDENTIALS") as exc:
+        eapi_accounts.configured_accounts()
+    assert raw not in str(exc.value)
+
+
+async def test_concurrent_downloads_recheck_quota_after_previous_download(accounts):
+    import asyncio
+
+    used = [9, 0]
+    selected_indices = []
+
+    async def initialize(account):
+        index = accounts.index(account)
+        value = client(10, used[index])
+        return value
+
+    async def download():
+        async with eapi_accounts.download_client(accounts, initialize) as (index, _):
+            selected_indices.append(index)
+            used[index - 1] += 1
+
+    await asyncio.gather(download(), download())
+    assert selected_indices == [1, 2]
+
+
+async def test_bridge_dispatch_download_uses_selected_account(
+    accounts, monkeypatch, capsys
+):
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "lib"))
+    import python_bridge
+
+    first, second = client(10, 10), client(10, 3)
+    initialize = AsyncMock(side_effect=[first, second])
+    monkeypatch.setattr(python_bridge, "_initialize_account", initialize)
+    monkeypatch.setattr(python_bridge, "_eapi_client", None)
+    monkeypatch.setattr(
+        python_bridge,
+        "_dispatch_bridge_function",
+        AsyncMock(return_value={"file_path": "book.epub"}),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "python_bridge.py",
+            "download_book",
+            '{"book_details":{"id":"123","hash":"abc"}}',
+        ],
+    )
+    await python_bridge.main()
+    payload = json.loads(capsys.readouterr().out)
+    assert json.loads(payload["content"][0]["text"])["account_index"] == 2
+    assert initialize.await_count == 2
+
+
+async def test_limits_tool_reports_pool_total_so_exhausted_first_account_does_not_hide_capacity(
+    accounts, monkeypatch
+):
+    import python_bridge
+
+    first, second = client(10, 10), client(15, 3)
+    monkeypatch.setattr(python_bridge, "get_eapi_client", AsyncMock(return_value=first))
+    monkeypatch.setattr(
+        python_bridge, "_initialize_account", AsyncMock(side_effect=[first, second])
+    )
+    result = await python_bridge.get_download_limits()
+    assert result["daily_limit"] == 25
+    assert result["daily_remaining"] == 12
+    assert [a["daily_remaining"] for a in result["accounts"]] == [0, 12]
+    assert "@" not in json.dumps(result)

--- a/__tests__/python/test_eapi_domain_resilience.py
+++ b/__tests__/python/test_eapi_domain_resilience.py
@@ -262,7 +262,8 @@ class TestSelectAdvertisedDomain:
 
 
 @pytest.fixture
-def eapi_env(monkeypatch):
+def eapi_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("ZLIBRARY_SESSION_DIR", str(tmp_path / "sessions"))
     monkeypatch.setenv("ZLIBRARY_EMAIL", "test@example.com")
     monkeypatch.setenv("ZLIBRARY_PASSWORD", "secret")
 
@@ -281,6 +282,7 @@ def make_client_mock():
         return_value={"domains": ["z-library.sk", "z-library.mx"]}
     )
     client.close = AsyncMock()
+    client.domain = "z-library.ec"
     client.remix_userid = "1"
     client.remix_userkey = "k"
     return client

--- a/__tests__/python/test_eapi_session.py
+++ b/__tests__/python/test_eapi_session.py
@@ -1,0 +1,245 @@
+"""Cross-call authentication behavior; no third-party requests."""
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "lib"))
+import python_bridge
+from zlibrary.eapi import EAPIClient
+
+
+@pytest.fixture
+def service(monkeypatch, tmp_path):
+    monkeypatch.setenv("ZLIBRARY_SESSION_DIR", str(tmp_path / "sessions"))
+    monkeypatch.setenv("ZLIBRARY_EMAIL", "reader@example.test")
+    monkeypatch.setenv("ZLIBRARY_PASSWORD", "test-credential-only")
+    monkeypatch.setenv("ZLIBRARY_EAPI_DOMAIN", "library.example.test")
+    state = {
+        "logins": 0,
+        "profiles": 0,
+        "expired": False,
+        "profile_error": None,
+        "limited": False,
+    }
+
+    def handle(request):
+        if request.url.path == "/eapi/user/login":
+            state["logins"] += 1
+            if state["limited"]:
+                return httpx.Response(
+                    400,
+                    json={
+                        "success": 0,
+                        "error": "Too many logins #2. Try again later.",
+                    },
+                )
+            state["expired"] = False
+            return httpx.Response(
+                200,
+                json={
+                    "success": 1,
+                    "user": {"id": 123, "remix_userkey": "test-cookie-value"},
+                },
+            )
+        assert request.url.path == "/eapi/user/profile"
+        state["profiles"] += 1
+        assert "remix_userkey=test-cookie-value" in request.headers["cookie"]
+        if state["profile_error"]:
+            raise httpx.ConnectError("offline", request=request)
+        if state["expired"]:
+            return httpx.Response(400, json={"success": 0, "error": "Please login"})
+        return httpx.Response(200, json={"success": 1, "user": {"id": 123}})
+
+    async def get_client(self):
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(
+                transport=httpx.MockTransport(handle), cookies=self._cookies
+            )
+        return self._client
+
+    monkeypatch.setattr(EAPIClient, "_get_client", get_client)
+    monkeypatch.setattr(python_bridge, "_eapi_client", None)
+    return state
+
+
+async def call_and_close():
+    client = await python_bridge.initialize_eapi_client()
+    await client.close()
+    python_bridge._eapi_client = None  # next bridge has no module-level state
+
+
+async def test_consecutive_bridge_calls_login_only_once(service):
+    await call_and_close()
+    await call_and_close()
+    assert service["logins"] == 1
+    assert service["profiles"] == 1
+
+
+async def test_expired_cookie_is_replaced_once(service):
+    await call_and_close()
+    service["expired"] = True
+    await call_and_close()
+    await call_and_close()
+    assert service["logins"] == 2
+
+
+async def test_network_failure_does_not_trigger_login(service):
+    await call_and_close()
+    service["profile_error"] = True
+    with pytest.raises(httpx.ConnectError):
+        await call_and_close()
+    assert service["logins"] == 1
+    service["profile_error"] = None
+    await call_and_close()
+    assert service["logins"] == 1
+
+
+async def test_changed_password_cannot_reuse_session(service, monkeypatch):
+    await call_and_close()
+    monkeypatch.setenv("ZLIBRARY_PASSWORD", "different-test-credential")
+    await call_and_close()
+    assert service["logins"] == 2
+
+
+async def test_concurrent_calls_share_one_login(service):
+    await asyncio.gather(*(call_and_close() for _ in range(4)))
+    assert service["logins"] == 1
+
+
+async def test_login_limit_has_clear_error_and_suppresses_immediate_retries(service):
+    service["limited"] = True
+    for _ in range(2):
+        with pytest.raises(RuntimeError, match="Too many logins"):
+            await call_and_close()
+    assert service["logins"] == 1
+
+
+async def test_session_is_private_and_contains_no_password(service, monkeypatch):
+    await call_and_close()
+    root = Path(os.environ["ZLIBRARY_SESSION_DIR"])
+    assert root.is_dir()
+    assert root.stat().st_mode & 0o777 == 0o700
+    files = list(root.glob("*.json"))
+    assert len(files) == 1
+    assert files[0].stat().st_mode & 0o777 == 0o600
+    assert "test-credential-only" not in files[0].read_text()
+    assert "reader@example.test" not in files[0].read_text()
+
+
+async def test_account_and_domain_changes_do_not_share_cookies(service, monkeypatch):
+    await call_and_close()
+    monkeypatch.setenv("ZLIBRARY_EMAIL", "another-reader@example.test")
+    await call_and_close()
+    monkeypatch.setenv("ZLIBRARY_EAPI_DOMAIN", "another.example.test")
+    await call_and_close()
+    assert service["logins"] == 3
+
+
+async def test_corrupt_session_is_replaced(service):
+    await call_and_close()
+    path = next(Path(os.environ["ZLIBRARY_SESSION_DIR"]).glob("*.json"))
+    path.write_text("{broken")
+    await call_and_close()
+    await call_and_close()
+    assert service["logins"] == 2
+
+
+async def test_public_session_directory_is_rejected_before_login(service):
+    root = Path(os.environ["ZLIBRARY_SESSION_DIR"])
+    root.mkdir(mode=0o755)
+    root.chmod(0o755)
+    with pytest.raises(RuntimeError, match="0700"):
+        await call_and_close()
+    assert service["logins"] == 0
+
+
+async def test_symlink_session_directory_is_rejected(service, tmp_path, monkeypatch):
+    target = tmp_path / "target"
+    target.mkdir(mode=0o700)
+    link = tmp_path / "link"
+    link.symlink_to(target, target_is_directory=True)
+    monkeypatch.setenv("ZLIBRARY_SESSION_DIR", str(link))
+    with pytest.raises(RuntimeError, match="symlink"):
+        await call_and_close()
+    assert service["logins"] == 0
+
+
+async def test_cancelled_lock_holder_does_not_block_next_call(tmp_path):
+    from lib.eapi_session import _locked
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def hold():
+        async with _locked(tmp_path / "session.lock"):
+            entered.set()
+            await release.wait()
+
+    task = asyncio.create_task(hold())
+    await entered.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    async def reacquire():
+        async with _locked(tmp_path / "session.lock"):
+            pass
+
+    await asyncio.wait_for(reacquire(), timeout=1)
+
+
+async def test_separate_python_processes_share_one_login(service, tmp_path):
+    """Exercise the actual bridge lifecycle, not just a cached Python global."""
+    script = r"""
+import asyncio, os, sys
+from pathlib import Path
+import httpx
+sys.path.insert(0, "lib")
+import python_bridge
+from zlibrary.eapi import EAPIClient
+
+def handle(request):
+    if request.url.path == "/eapi/user/login":
+        with open(os.environ["LOGIN_COUNTER"], "a") as out:
+            out.write("login\n")
+        return httpx.Response(200, json={"success": 1, "user": {"id": 123, "remix_userkey": "test-cookie"}})
+    assert request.url.path == "/eapi/user/profile"
+    assert "remix_userkey=test-cookie" in request.headers["cookie"]
+    return httpx.Response(200, json={"success": 1, "user": {"id": 123}})
+
+async def get_client(self):
+    if self._client is None or self._client.is_closed:
+        self._client = httpx.AsyncClient(transport=httpx.MockTransport(handle), cookies=self._cookies)
+    return self._client
+
+EAPIClient._get_client = get_client
+async def run():
+    client = await python_bridge.initialize_eapi_client()
+    await client.close()
+asyncio.run(run())
+"""
+    counter = tmp_path / "logins.txt"
+    env = {**os.environ, "LOGIN_COUNTER": str(counter)}
+    root = Path(__file__).resolve().parents[2]
+
+    async def child():
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-c",
+            script,
+            cwd=root,
+            env=env,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=15)
+        assert proc.returncode == 0, stderr.decode()
+        assert stdout == b""
+
+    await asyncio.gather(*(child() for _ in range(3)))
+    assert counter.read_text().splitlines() == ["login"]

--- a/__tests__/python/test_eapi_session.py
+++ b/__tests__/python/test_eapi_session.py
@@ -1,6 +1,7 @@
 """Cross-call authentication behavior; no third-party requests."""
 
 import asyncio
+import json
 import os
 import sys
 from pathlib import Path
@@ -243,3 +244,149 @@ asyncio.run(run())
 
     await asyncio.gather(*(child() for _ in range(3)))
     assert counter.read_text().splitlines() == ["login"]
+
+
+@pytest.fixture
+def rotating_domains(monkeypatch, tmp_path):
+    from zlibrary import eapi
+
+    monkeypatch.setenv("ZLIBRARY_SESSION_DIR", str(tmp_path / "sessions"))
+    monkeypatch.setenv("ZLIBRARY_EMAIL", "reader@example.test")
+    monkeypatch.setenv("ZLIBRARY_PASSWORD", "offline-domain-recovery-credential")
+    monkeypatch.delenv("ZLIBRARY_ACCOUNT_CREDENTIALS", raising=False)
+    monkeypatch.delenv("ZLIBRARY_EAPI_DOMAIN", raising=False)
+    monkeypatch.setattr(
+        eapi, "DEFAULT_EAPI_DOMAINS", ["a.example.test", "b.example.test"]
+    )
+    state = {
+        "failure": None,
+        "b_failure": None,
+        "b_profile_failure": None,
+        "logins": 0,
+        "profiles": [],
+        "clients": [],
+    }
+
+    def handle(request):
+        domain = request.url.host
+        failure = state["failure"] if domain == "a.example.test" else state["b_failure"]
+        if request.url.path == "/eapi/user/profile":
+            state["profiles"].append(domain)
+            assert "remix_userkey=offline-cookie" in request.headers["cookie"]
+            if domain == "b.example.test":
+                failure = state["b_profile_failure"] or failure
+        if failure == "network":
+            raise httpx.ConnectError("domain unavailable", request=request)
+        if failure == "wall":
+            return httpx.Response(513, text="DiamWall")
+        if failure == "upstream":
+            return httpx.Response(503, text="Unavailable")
+        if request.url.path == "/eapi/info/domains":
+            return httpx.Response(200, json={"domains": []})
+        if request.url.path == "/eapi/user/login":
+            state["logins"] += 1
+            return httpx.Response(
+                200,
+                json={
+                    "success": 1,
+                    "user": {"id": 123, "remix_userkey": "offline-cookie"},
+                },
+            )
+        assert request.url.path == "/eapi/user/profile"
+        if failure == "expired":
+            return httpx.Response(401, json={"error": "Please login"})
+        return httpx.Response(200, json={"success": 1, "user": {"id": 123}})
+
+    transport = httpx.MockTransport(handle)
+
+    async def get_client(self):
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(transport=transport, cookies=self._cookies)
+            state["clients"].append(self._client)
+        return self._client
+
+    async def resolve():
+        return await eapi.resolve_eapi_domain(transport=transport)
+
+    monkeypatch.setattr(EAPIClient, "_get_client", get_client)
+    monkeypatch.setattr(python_bridge, "resolve_eapi_domain", resolve)
+    monkeypatch.setattr(python_bridge, "_eapi_client", None)
+    return state
+
+
+@pytest.mark.parametrize("failure", ["network", "wall", "upstream"])
+async def test_cached_session_recovers_domain_without_login(rotating_domains, failure):
+    await call_and_close()
+    rotating_domains["failure"] = failure
+    await call_and_close()
+    await call_and_close()
+    assert rotating_domains["logins"] == 1
+    assert rotating_domains["profiles"] == [
+        "a.example.test",
+        "b.example.test",
+        "b.example.test",
+    ]
+    record = json.loads(
+        next(Path(os.environ["ZLIBRARY_SESSION_DIR"]).glob("*.json")).read_text()
+    )
+    assert record["domain"] == "b.example.test"
+    assert all(client.is_closed for client in rotating_domains["clients"])
+
+
+@pytest.mark.parametrize("failure", ["network", "wall"])
+async def test_pinned_cached_domain_does_not_switch(
+    rotating_domains, monkeypatch, failure
+):
+    from zlibrary.eapi import DiamWallError
+
+    monkeypatch.setenv("ZLIBRARY_EAPI_DOMAIN", "a.example.test")
+    await call_and_close()
+    rotating_domains["failure"] = failure
+    with pytest.raises((httpx.ConnectError, DiamWallError)):
+        await call_and_close()
+    assert rotating_domains["logins"] == 1
+    assert rotating_domains["profiles"] == ["a.example.test"]
+    assert all(client.is_closed for client in rotating_domains["clients"])
+
+
+async def test_failed_domain_recovery_retains_cookies_without_login(rotating_domains):
+    await call_and_close()
+    path = next(Path(os.environ["ZLIBRARY_SESSION_DIR"]).glob("*.json"))
+    original = path.read_bytes()
+    rotating_domains["failure"] = "network"
+    rotating_domains["b_failure"] = "network"
+    with pytest.raises(httpx.ConnectError):
+        await call_and_close()
+    assert path.read_bytes() == original
+    assert rotating_domains["logins"] == 1
+    assert all(client.is_closed for client in rotating_domains["clients"])
+    rotating_domains["b_failure"] = None
+    await call_and_close()
+    assert rotating_domains["logins"] == 1
+
+
+async def test_expired_cookies_on_recovered_domain_allow_login(rotating_domains):
+    await call_and_close()
+    rotating_domains["failure"] = "network"
+    rotating_domains["b_failure"] = "expired"
+    await call_and_close()
+    assert rotating_domains["logins"] == 2
+    assert rotating_domains["profiles"] == ["a.example.test", "b.example.test"]
+    assert all(client.is_closed for client in rotating_domains["clients"])
+
+
+@pytest.mark.parametrize("failure", ["network", "wall", "upstream"])
+async def test_recovered_domain_profile_failure_keeps_cache(rotating_domains, failure):
+    from zlibrary.eapi import DiamWallError
+
+    await call_and_close()
+    path = next(Path(os.environ["ZLIBRARY_SESSION_DIR"]).glob("*.json"))
+    original = path.read_bytes()
+    rotating_domains["failure"] = "network"
+    rotating_domains["b_profile_failure"] = failure
+    with pytest.raises((httpx.ConnectError, httpx.HTTPStatusError, DiamWallError)):
+        await call_and_close()
+    assert rotating_domains["profiles"] == ["a.example.test", "b.example.test"]
+    assert rotating_domains["logins"] == 1
+    assert path.read_bytes() == original
+    assert all(client.is_closed for client in rotating_domains["clients"])

--- a/__tests__/stdio-purity.test.js
+++ b/__tests__/stdio-purity.test.js
@@ -45,7 +45,7 @@ describe('stdio purity', () => {
     expect(offenders).toEqual([]);
   });
 
-  test('every stdout line from a real handshake is valid JSON-RPC', async () => {
+  test.each(['legacy', 'pool'])('every stdout line from a real %s handshake is valid JSON-RPC', async (mode) => {
     if (!existsSync(distEntry)) {
       throw new Error(`dist/index.js missing — run "npm run build" before this test`);
     }
@@ -66,14 +66,17 @@ describe('stdio purity', () => {
       const child = spawn(process.execPath, [distEntry], {
         env: {
           ...process.env,
-          ZLIBRARY_EMAIL: 'ci@test.com',
-          ZLIBRARY_PASSWORD: 'ci-test-password',
+          ZLIBRARY_EMAIL: mode === 'legacy' ? 'ci@test.com' : '',
+          ZLIBRARY_PASSWORD: mode === 'legacy' ? 'ci-test-password' : '',
+          ZLIBRARY_ACCOUNT_CREDENTIALS: mode === 'pool' ? JSON.stringify([{ email: 'ci@test.com', password: 'ci-test-password' }]) : '',
           LOG_LEVEL: 'debug', // strictest case: even debug output must avoid stdout
         },
         stdio: ['pipe', 'pipe', 'pipe'],
       });
 
       let out = '';
+      let err = '';
+      child.stderr.on('data', (chunk) => { err += chunk.toString(); });
       child.stdout.on('data', (chunk) => {
         out += chunk.toString();
       });
@@ -81,17 +84,18 @@ describe('stdio purity', () => {
 
       const done = setTimeout(() => {
         child.kill();
-        resolve(out);
+        resolve({ out, err });
       }, 8000);
       child.on('close', () => {
         clearTimeout(done);
-        resolve(out);
+        resolve({ out, err });
       });
 
       child.stdin.write(`${initialize}\n${initialized}\n`);
     });
 
-    const lines = stdout.split('\n').filter((line) => line.trim() !== '');
+    expect(stdout.err).not.toContain('Missing environment variable(s)');
+    const lines = stdout.out.split('\n').filter((line) => line.trim() !== '');
     expect(lines.length).toBeGreaterThan(0);
 
     for (const line of lines) {

--- a/docs/specifications/EAPI_SESSION_REUSE.md
+++ b/docs/specifications/EAPI_SESSION_REUSE.md
@@ -1,0 +1,29 @@
+# EAPI session reuse
+
+## Incident and scope
+
+On 2026-09-05, consecutive Trivet searches/downloads failed at login with HTTP 400 and `Too many logins #2. Try again later.` Each Node tool call starts a fresh Python bridge; its module-level client does not survive the call.
+
+Persist only EAPI session cookies in a private directory outside download artifacts. Keep the existing Python process lifecycle, domain probing, source routing, and download behavior.
+
+## Acceptance
+
+- Sequential and concurrent bridge processes using the same credentials perform one successful login and reuse its cookies.
+- Validate cached cookies with `/eapi/user/profile`; only an explicit authentication rejection causes one fresh login. Network errors, walls, and unrelated business errors must not cause logins.
+- Credential or explicit-domain changes cannot reuse a previous session.
+- The session directory and files are private; writes are atomic; credentials and cookies never appear in diagnostics.
+- An upstream login-limit rejection is readable, and a short local cooldown prevents subsequent calls from immediately repeating it. This cooldown is not an estimate of upstream recovery time.
+- Missing credentials and credential-free source behavior remain unchanged.
+
+## Verification and delivery
+
+1. Python bridge/session helper and behavioral tests: run session, domain-resilience, and bridge regressions, including separate-process concurrency.
+2. Publish a PR with evidence; stage a separate deployment directory and verify two real calls without a second login before reporting runtime reuse verified. Keep the old deployment available for rollback.
+
+No upstream merge or account changes are included. If the existing login limit persists, report that limitation without attempting repeated logins.
+
+## Automatic account selection (requested in the same task)
+
+`ZLIBRARY_ACCOUNT_CREDENTIALS` accepts a JSON array of `{email, password}` objects. It takes precedence over the legacy single-account pair, which remains supported. Trivet already encrypts environment settings and masks credential-named entries. Do not put account values in tool arguments or logs.
+
+For Z-Library downloads with a configured pool, read real `downloads_limit` and `downloads_today` values and choose the first account with positive remaining quota. Serialize selection plus download across bridge processes sharing the session directory. Search can use the first account even if its download quota is spent. Do not rotate on login errors, unknown quota, network failures, or uncertain download results. Do not retry an already-dispatched download on another account. All exhausted accounts produce an actionable error; no quota values or reset time are assumed.

--- a/docs/specifications/EAPI_SESSION_REUSE.md
+++ b/docs/specifications/EAPI_SESSION_REUSE.md
@@ -10,6 +10,7 @@ Persist only EAPI session cookies in a private directory outside download artifa
 
 - Sequential and concurrent bridge processes using the same credentials perform one successful login and reuse its cookies.
 - Validate cached cookies with `/eapi/user/profile`; only an explicit authentication rejection causes one fresh login. Network errors, walls, and unrelated business errors must not cause logins.
+- If a cached domain becomes unreachable or walled and no domain is explicitly pinned, rediscover a working domain and validate the existing cookies there. Save the new domain only after successful validation; failed recovery preserves the cache and never triggers login. Cover A-to-B recovery, explicit pins, unavailable candidates, and profile failures on the replacement domain with offline transport tests.
 - Credential or explicit-domain changes cannot reuse a previous session.
 - The session directory and files are private; writes are atomic; credentials and cookies never appear in diagnostics.
 - An upstream login-limit rejection is readable, and a short local cooldown prevents subsequent calls from immediately repeating it. This cooldown is not an estimate of upstream recovery time.

--- a/lib/eapi_accounts.py
+++ b/lib/eapi_accounts.py
@@ -1,0 +1,108 @@
+"""Account configuration and quota-based selection for EAPI downloads."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+import json
+import os
+
+from lib.eapi_session import _locked, _private_directory
+
+
+@dataclass(frozen=True)
+class Account:
+    email: str = field(repr=False)
+    password: str = field(repr=False)
+
+
+def configured_accounts() -> list[Account]:
+    raw = os.environ.get("ZLIBRARY_ACCOUNT_CREDENTIALS", "").strip()
+    if not raw:
+        email = os.environ.get("ZLIBRARY_EMAIL")
+        password = os.environ.get("ZLIBRARY_PASSWORD")
+        if not email or not password:
+            raise ValueError(
+                "ZLIBRARY_EMAIL and ZLIBRARY_PASSWORD environment variables required, or configure ZLIBRARY_ACCOUNT_CREDENTIALS"
+            )
+        return [Account(email, password)]
+    message = "ZLIBRARY_ACCOUNT_CREDENTIALS must be a non-empty JSON array of unique email/password objects"
+    try:
+        values = json.loads(raw)
+    except ValueError:
+        raise ValueError(message) from None
+    if not isinstance(values, list) or not values:
+        raise ValueError(message)
+    accounts = []
+    seen = set()
+    for value in values:
+        if not isinstance(value, dict) or any(
+            not isinstance(value.get(k), str) or not value[k].strip()
+            for k in ("email", "password")
+        ):
+            raise ValueError(message)
+        email = value["email"].strip()
+        if email.lower() in seen:
+            raise ValueError(message)
+        seen.add(email.lower())
+        accounts.append(Account(email, value["password"]))
+    return accounts
+
+
+@asynccontextmanager
+async def download_client(accounts, initialize):
+    # Hold selection and download together: concurrent bridge processes cannot
+    # both spend the last observed slot. Never replay an uncertain download.
+    async with _locked(_private_directory() / "downloads.lock"):
+        for index, account in enumerate(accounts, 1):
+            client = await initialize(account)
+            try:
+                profile = await client.get_profile()
+                quota = _quota(profile, index)
+                if quota["daily_remaining"] > 0:
+                    yield index, client
+                    return
+            finally:
+                await client.close()
+        raise RuntimeError(
+            "All configured Z-Library accounts have exhausted their download quota"
+        )
+
+
+def _quota(profile: dict, index: int) -> dict:
+    user = profile.get("user")
+    user = user if isinstance(user, dict) else {}
+    limit, used = user.get("downloads_limit"), user.get("downloads_today")
+    if (
+        profile.get("success") != 1
+        or type(limit) is not int
+        or type(used) is not int
+        or min(limit, used) < 0
+    ):
+        raise RuntimeError(
+            f"Download quota for account {index} is unknown; automatic selection stopped"
+        )
+    return {
+        "account_index": index,
+        "daily_limit": limit,
+        "daily_remaining": max(0, limit - used),
+        "downloads_today": used,
+        "is_premium": bool(user.get("isPremium", 0)),
+    }
+
+
+async def pool_limits(accounts, initialize) -> dict:
+    summaries = []
+    for index, account in enumerate(accounts, 1):
+        client = await initialize(account)
+        try:
+            summaries.append(_quota(await client.get_profile(), index))
+        finally:
+            await client.close()
+    result = {
+        key: sum(row[key] for row in summaries)
+        for key in ("daily_limit", "daily_remaining", "downloads_today")
+    }
+    result["is_premium"] = any(row["is_premium"] for row in summaries)
+    result["accounts"] = summaries
+    return result

--- a/lib/eapi_session.py
+++ b/lib/eapi_session.py
@@ -1,0 +1,219 @@
+"""Private, process-shared EAPI cookies for the short-lived Python bridge."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+import hashlib
+import json
+import logging
+import os
+from pathlib import Path
+import stat
+import tempfile
+import time
+
+import httpx
+
+if os.name == "nt":
+    import msvcrt
+else:
+    import fcntl
+
+logger = logging.getLogger("zlibrary")
+# A local brake, not a prediction of when the upstream limit will reset.
+LOGIN_COOLDOWN_SECONDS = 300
+LIMIT_MESSAGE = (
+    "Too many logins. Z-Library temporarily rejected login; try again later."
+)
+
+
+def _private_directory() -> Path:
+    root = Path(
+        os.environ.get("ZLIBRARY_SESSION_DIR")
+        or Path.home() / ".cache" / "zlibrary-mcp" / "sessions"
+    )
+    root.mkdir(mode=0o700, parents=True, exist_ok=True)
+    info = root.lstat()
+    if not stat.S_ISDIR(info.st_mode):
+        raise RuntimeError("EAPI session directory must not be a symlink")
+    if os.name != "nt" and (info.st_uid != os.getuid() or info.st_mode & 0o077):
+        raise RuntimeError(
+            "EAPI session directory must be owned by the current user with mode 0700"
+        )
+    return root
+
+
+def _open_private(path: Path, flags: int) -> int:
+    fd = os.open(path, flags | getattr(os, "O_NOFOLLOW", 0), 0o600)
+    info = os.fstat(fd)
+    if not stat.S_ISREG(info.st_mode) or (
+        os.name != "nt" and (info.st_uid != os.getuid() or info.st_mode & 0o077)
+    ):
+        os.close(fd)
+        raise RuntimeError("EAPI session files must be private regular files (0600)")
+    return fd
+
+
+@asynccontextmanager
+async def _locked(path: Path):
+    fd = _open_private(path, os.O_CREAT | os.O_RDWR)
+    acquired = False
+    deadline = time.monotonic() + 30
+    try:
+        if os.name == "nt" and os.fstat(fd).st_size == 0:
+            os.write(fd, b"\0")
+        while not acquired:
+            try:
+                if os.name == "nt":
+                    os.lseek(fd, 0, os.SEEK_SET)
+                    msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+                else:
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                acquired = True
+            except (BlockingIOError, PermissionError):
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(
+                        "Timed out waiting for the EAPI session lock"
+                    ) from None
+                # Wait on lock availability, without blocking the event loop.
+                await asyncio.sleep(0.05)
+        yield
+    finally:
+        if acquired:
+            if os.name == "nt":
+                os.lseek(fd, 0, os.SEEK_SET)
+                msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+            else:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+def _read(path: Path) -> dict:
+    try:
+        fd = _open_private(path, os.O_RDONLY)
+    except FileNotFoundError:
+        return {}
+    with os.fdopen(fd) as handle:
+        try:
+            value = json.load(handle)
+        except (ValueError, UnicodeError):
+            return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _write(path: Path, value: dict):
+    fd, name = tempfile.mkstemp(prefix=".session-", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w") as handle:
+            json.dump(value, handle)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(name, path)
+    finally:
+        if os.path.exists(name):
+            os.unlink(name)
+
+
+def _response_error(exc: httpx.HTTPStatusError) -> str:
+    try:
+        payload = exc.response.json()
+    except ValueError:
+        return ""
+    return payload.get("error", "") if isinstance(payload, dict) else ""
+
+
+async def _is_authenticated(client) -> bool:
+    try:
+        profile = await client.get_profile()
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 401 or (
+            exc.response.status_code == 400 and _response_error(exc) == "Please login"
+        ):
+            return False
+        raise
+    if profile.get("success") == 0 and profile.get("error") == "Please login":
+        return False
+    user = profile.get("user")
+    if (
+        profile.get("success") == 1
+        and isinstance(user, dict)
+        and str(user.get("id")) == str(client.remix_userid)
+    ):
+        return True
+    raise RuntimeError(
+        "Unexpected EAPI profile response; cached session retained without re-login"
+    )
+
+
+async def authenticated_client(email: str, password: str, login, client_factory):
+    """Validate shared cookies, or serialize a single login and atomic save."""
+    root = _private_directory()
+    account = hashlib.sha256(email.encode()).hexdigest()
+    fingerprint = hashlib.sha256(
+        json.dumps(
+            [email, password, os.environ.get("ZLIBRARY_EAPI_DOMAIN", "").strip()]
+        ).encode()
+    ).hexdigest()
+    path = root / f"{account}.json"
+    async with _locked(root / f"{account}.lock"):
+        record = _read(path)
+        if record.get("fingerprint") != fingerprint:
+            record = {}
+        retry_after = record.get("retry_after", 0)
+        if isinstance(retry_after, (int, float)) and retry_after > time.time():
+            raise RuntimeError(LIMIT_MESSAGE + " Local retry cooldown is active.")
+        if all(
+            isinstance(record.get(k), str) and record[k]
+            for k in ("domain", "userid", "userkey")
+        ):
+            client = client_factory(
+                record["domain"],
+                remix_userid=record["userid"],
+                remix_userkey=record["userkey"],
+            )
+            try:
+                valid = await _is_authenticated(client)
+            except BaseException:
+                await client.close()
+                raise
+            if valid:
+                logger.info("Reused cached EAPI session")
+                return client
+            await client.close()
+            # The next caller must not retry a known invalid session.
+            _write(path, {"fingerprint": fingerprint})
+        try:
+            client = await login()
+        except httpx.HTTPStatusError as exc:
+            error = _response_error(exc)
+            if (
+                exc.response.status_code in (400, 429)
+                and isinstance(error, str)
+                and error.startswith("Too many logins")
+            ):
+                _write(
+                    path,
+                    {
+                        "fingerprint": fingerprint,
+                        "retry_after": time.time() + LOGIN_COOLDOWN_SECONDS,
+                    },
+                )
+                raise RuntimeError(LIMIT_MESSAGE) from None
+            raise
+        try:
+            if not client.remix_userid or not client.remix_userkey:
+                raise RuntimeError("EAPI login returned no session cookies")
+            _write(
+                path,
+                {
+                    "fingerprint": fingerprint,
+                    "domain": client.domain,
+                    "userid": str(client.remix_userid),
+                    "userkey": str(client.remix_userkey),
+                },
+            )
+        except BaseException:
+            await client.close()
+            raise
+        return client

--- a/lib/eapi_session.py
+++ b/lib/eapi_session.py
@@ -14,6 +14,7 @@ import tempfile
 import time
 
 import httpx
+from zlibrary.eapi import DiamWallError
 
 if os.name == "nt":
     import msvcrt
@@ -146,7 +147,9 @@ async def _is_authenticated(client) -> bool:
     )
 
 
-async def authenticated_client(email: str, password: str, login, client_factory):
+async def authenticated_client(
+    email: str, password: str, login, client_factory, resolve_domain
+):
     """Validate shared cookies, or serialize a single login and atomic save."""
     root = _private_directory()
     account = hashlib.sha256(email.encode()).hexdigest()
@@ -173,7 +176,25 @@ async def authenticated_client(email: str, password: str, login, client_factory)
                 remix_userkey=record["userkey"],
             )
             try:
-                valid = await _is_authenticated(client)
+                try:
+                    valid = await _is_authenticated(client)
+                except (httpx.RequestError, httpx.HTTPStatusError, DiamWallError):
+                    await client.close()
+                    if os.environ.get("ZLIBRARY_EAPI_DOMAIN", "").strip():
+                        raise
+                    domain = await resolve_domain()
+                    if domain == record["domain"]:
+                        raise
+                    client = client_factory(
+                        domain,
+                        remix_userid=record["userid"],
+                        remix_userkey=record["userkey"],
+                    )
+                    # Only explicit authentication rejection permits a login.
+                    # A failed recovery leaves the shared cookies unchanged.
+                    valid = await _is_authenticated(client)
+                    if valid:
+                        _write(path, {**record, "domain": client.domain})
             except BaseException:
                 await client.close()
                 raise

--- a/lib/python_bridge.py
+++ b/lib/python_bridge.py
@@ -26,6 +26,8 @@ from lib import rag_processing
 
 # Import enhanced metadata extraction
 from lib import enhanced_metadata
+from lib.eapi_session import authenticated_client
+from lib.eapi_accounts import configured_accounts, download_client, pool_limits
 
 # Import multi-source router
 from lib.sources.router import SourceRouter
@@ -264,25 +266,23 @@ async def get_eapi_client() -> EAPIClient:
 
 
 async def initialize_eapi_client() -> EAPIClient:
-    """
-    Initialize the shared EAPI client using environment credentials.
+    """Reuse the first account for search, health, and history operations."""
+    return await _initialize_account(configured_accounts()[0])
 
-    Creates an EAPIClient, logs in, discovers domains, and stores
-    the client for reuse by all tool functions.
 
-    Returns:
-        Authenticated EAPIClient instance
-    """
+async def _initialize_account(account) -> EAPIClient:
     global _eapi_client
+    _eapi_client = await authenticated_client(
+        account.email,
+        account.password,
+        lambda: _login_eapi_client(account.email, account.password),
+        EAPIClient,
+    )
+    return _eapi_client
 
-    email = os.environ.get("ZLIBRARY_EMAIL")
-    password = os.environ.get("ZLIBRARY_PASSWORD")
 
-    if not email or not password:
-        raise ValueError(
-            "ZLIBRARY_EMAIL and ZLIBRARY_PASSWORD environment variables required"
-        )
-
+async def _login_eapi_client(email: str, password: str) -> EAPIClient:
+    """Perform one login and retain the existing domain-discovery behavior."""
     # ISSUE-API-002: the old single default (z-library.sk) is fronted by the
     # DiamWall anti-bot wall. resolve_eapi_domain() honours an explicit
     # ZLIBRARY_EAPI_DOMAIN override without probing; otherwise it probes the
@@ -292,10 +292,15 @@ async def initialize_eapi_client() -> EAPIClient:
     initial_domain = await resolve_eapi_domain()
 
     client = EAPIClient(initial_domain)
-    login_result = await client.login(email, password)
+    try:
+        login_result = await client.login(email, password)
+    except BaseException:
+        await client.close()
+        raise
 
     if login_result.get("success") != 1:
-        raise RuntimeError(f"EAPI login failed: {login_result}")
+        await client.close()
+        raise RuntimeError("EAPI login failed")
 
     logger.info(f"EAPI client authenticated (userid={client.remix_userid})")
 
@@ -326,8 +331,7 @@ async def initialize_eapi_client() -> EAPIClient:
         except Exception as e:
             logger.warning(f"Domain discovery failed, using initial domain: {e}")
 
-    _eapi_client = client
-    return _eapi_client
+    return client
 
 
 def _classify_health_error(error: Exception) -> str:
@@ -677,6 +681,8 @@ async def get_download_limits():
         dict with daily_limit, daily_remaining (both int, or "unknown" if the
         response shape changes again), plus downloads_today and is_premium.
     """
+    if os.environ.get("ZLIBRARY_ACCOUNT_CREDENTIALS", "").strip():
+        return await pool_limits(configured_accounts(), _initialize_account)
     eapi = await get_eapi_client()
     profile = await eapi.get_profile()
     user = profile.get("user", profile)
@@ -1669,7 +1675,17 @@ async def main():
         # during asyncio.run() shutdown.
         resolver_timeout = get_source_config().preflight_timeout
         async with bounded_resolver(resolver_timeout):
-            if needs_eapi:
+            pooled_download = (
+                needs_eapi
+                and function_name == "download_book"
+                and bool(os.environ.get("ZLIBRARY_ACCOUNT_CREDENTIALS", "").strip())
+            )
+            pooled_limits = (
+                needs_eapi
+                and function_name == "get_download_limits"
+                and bool(os.environ.get("ZLIBRARY_ACCOUNT_CREDENTIALS", "").strip())
+            )
+            if needs_eapi and not pooled_download and not pooled_limits:
                 await initialize_eapi_client()
 
             # Standardize 'language' key to 'languages' for search functions.
@@ -1680,7 +1696,15 @@ async def main():
                     args_dict["languages"] = []
                 if not args_dict.get("content_types"):
                     args_dict["content_types"] = []
-            result = await _dispatch_bridge_function(function_name, args_dict)
+            if pooled_download:
+                async with download_client(
+                    configured_accounts(), _initialize_account
+                ) as (index, _):
+                    result = await _dispatch_bridge_function(function_name, args_dict)
+                    if isinstance(result, dict):
+                        result["account_index"] = index
+            else:
+                result = await _dispatch_bridge_function(function_name, args_dict)
 
         # Print only confirmation and path to stdout to avoid large content
         mcp_style_response = {"content": [{"type": "text", "text": json.dumps(result)}]}

--- a/lib/python_bridge.py
+++ b/lib/python_bridge.py
@@ -277,6 +277,7 @@ async def _initialize_account(account) -> EAPIClient:
         account.password,
         lambda: _login_eapi_client(account.email, account.password),
         EAPIClient,
+        resolve_eapi_domain,
     )
     return _eapi_client
 

--- a/scripts/validate-python-bridge.js
+++ b/scripts/validate-python-bridge.js
@@ -21,6 +21,8 @@ const projectRoot = resolve(__dirname, '..');
 // Required Python bridge files
 const requiredPythonFiles = [
   { path: 'lib/python_bridge.py', critical: true, description: 'Main Python bridge script' },
+  { path: 'lib/eapi_session.py', critical: true, description: 'Shared EAPI authentication' },
+  { path: 'lib/eapi_accounts.py', critical: true, description: 'EAPI account selection' },
   { path: 'lib/rag_processing.py', critical: true, description: 'RAG document processing' },
   { path: 'lib/enhanced_metadata.py', critical: true, description: 'Enhanced metadata extraction' },
   { path: 'lib/author_tools.py', critical: false, description: 'Author-specific search tools' },

--- a/src/index.ts
+++ b/src/index.ts
@@ -663,6 +663,8 @@ function wrapResult(result: any, toolName: string) {
  * Z-Library tools still fail with their own clear error when invoked.
  */
 function validateCredentials(): void {
+  // The Python bridge validates pool entries without logging their contents.
+  if (process.env.ZLIBRARY_ACCOUNT_CREDENTIALS?.trim()) return;
   const email = process.env.ZLIBRARY_EMAIL;
   const password = process.env.ZLIBRARY_PASSWORD;
 


### PR DESCRIPTION
## Problem

Each Node tool invocation starts a new Python bridge process, and `initialize_eapi_client()` logs in again. Keeping the Node MCP server alive therefore does not preserve EAPI authentication. Consecutive searches, quota checks, and downloads exhausted the upstream login allowance in a deployed Docker instance. One diagnostic request reproduced HTTP 400 with:

```json
{"success":0,"error":"Too many logins #2. Try again later."}
```

## Change

- Persist session cookies in a private directory outside download artifacts. Validate cached cookies through `/eapi/user/profile`; only explicit authentication rejection triggers another login. Serialize authentication across processes, use atomic writes, and invalidate reuse when credentials or the explicit domain change. No passwords are stored in the session cache or returned in tool results.
- Surface login throttling with a readable error and a five-minute local retry cooldown. The cooldown does not claim to predict upstream recovery time. Network errors and anti-bot responses do not trigger fresh logins.
- Add optional `ZLIBRARY_ACCOUNT_CREDENTIALS`, a secret JSON array of email/password objects. Before a pooled download, choose the first account with actual remaining quota and hold a process-shared lock through selection and download. Return a one-based account index rather than an email. Quota reporting includes both totals and per-account figures. Exhausted quotas, unknown quota, login errors, and uncertain download results do not trigger blind rotation or replay.
- Preserve the legacy single-account configuration and credential-free source paths. Update configuration documentation, startup detection, and bridge packaging validation.

## Verification

- Regression reproduced two logins for two consecutive calls and four logins for four concurrent calls before the fix. The new tests also exercise separate Python processes sharing one session.
- Python fast suite: **1369 passed**, 8 skipped, 185 deselected, 7 xfailed; **70.35%** coverage. Command:
  `uv run --with 'pillow==12.3.0' --with 'numpy==2.2.6' --with 'opencv-python-headless==5.0.0.93' pytest -m 'not slow and not integration and not performance' --benchmark-disable -rs`
  The additional optional test packages use versions already in the lockfile; this PR changes no dependencies.
- Focused session/account/domain/bridge regression suite: **146 passed**, repeated on the merged fork default branch.
- `npm run build`, Ruff, ESLint, and stdio handshake tests: **3 passed** (legacy credentials and pool-only configuration).
- Live Docker verification with an existing account: two independently started MCP clients produced one login and one cached-session reuse. Subsequent search and quota calls both reused the session, adding zero logins. Quota checks reported the same daily limit/usage/remaining values. No download quota was spent solely for validation.

## Limits

Only one real account was available. Cross-account selection, quota exhaustion, and concurrent last-slot selection are covered by mocked tests, not a live two-account test. POSIX permissions were verified on macOS/Linux; the Windows lock path has not been exercised on Windows. Other applications can still consume an account's quota outside this MCP's lock. Skipped fast-suite tests require optional NLTK data or Tesseract; slow/live integration/performance tests were excluded.


## Domain recovery review fix (2026-09-09)

Addresses review 5148850066. When a cached domain fails with a transport error, HTTP error, or DiamWall response, an unpinned session runs the existing domain discovery and validates the same cookies on the replacement domain. A successful profile validation atomically updates the cached domain. Explicit pins never switch. Failed discovery/validation preserves the cache and does not trigger login; explicit authentication rejection retains the existing re-login behavior. Recovery is bounded to one rediscovery per initialization and stays inside the existing account lock.

Verification on the updated PR branch, based on upstream master f779ee3:
- Before the fix, five new recovery cases failed on the original unavailable/walled domain.
- `python -m pytest __tests__/python/test_eapi_session.py __tests__/python/test_eapi_accounts.py __tests__/python/test_eapi_domain_resilience.py __tests__/python/test_python_bridge.py --no-cov -q`: **156 passed**, including **10 new domain-recovery cases**. Tests use `httpx.MockTransport`, the real domain resolver and EAPI client; no real accounts or download quota were used.
- `npm run build`: passed, including bridge packaging validation.
- `node --experimental-vm-modules node_modules/jest/bin/jest.js __tests__/stdio-purity.test.js --runInBand --coverage=false`: **3 passed**.
- Ruff check/format for all three changed Python files and `git diff --check`: passed.

Self-review found no blocking defects in this correction. The full Python suite, live service, Docker and Windows acceptance were not rerun for this correction. The earlier dependency-audit baseline issue and the separate account-selection policy decision (#166) remain outside this fix.
